### PR TITLE
add：仮のトップページを作成しました

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,4 @@
+class StaticPagesController < ApplicationController
+  def top
+  end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,0 +1,3 @@
+<h1>StaticPages#top</h1>
+<p>Find me in app/views/static_pages/top.html.erb</p>
+<h1>ここは仮のトップページです</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root "static_pages#top"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get top" do
+    get static_pages_top_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 概要
仮のトップページを作成しました。

## 該当Issue
#8 ：トップページ（仮）の作成

## 背景
画面遷移・表示確認用として仮のトップページを作成しました。

## 変更内容
- トップページ用のコントローラ / ビューを作成
- ルーティングをトップページに設定

## 確認方法
※環境構築は終えている前提です
1.  `http://localhost:3000` にアクセス
2. 仮のトップページが表示されることを確認
<img width="2126" height="1890" alt="image" src="https://github.com/user-attachments/assets/30cc1ebd-87a7-4aeb-a614-924fdf0ae357" />

## 補足
- 本トップページは仮なので最後に本番環境で運用するトップページを作成する予定です。