### PR TITLE
chore: ページタイトルを動的に表示するように実装

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  def page_title(title = '')
+    base_title = 'Figrune'
+    title.present? ? "#{title} - #{base_title}" : base_title
+  end
 end

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <div class="min-h-screen flex items-center justify-center px-4">
   <div class="w-full max-w-md bg-gray-100 rounded-2xl shadow-md p-8">
     <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <div class="min-h-screen flex items-center justify-center px-4">
   <div class="w-full max-w-md bg-gray-100 rounded-2xl shadow-md p-8">
     <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t('.title')) %>
 <div class="min-h-screen flex items-center justify-center px-4">
   <div class="w-full max-w-md bg-gray-100 rounded-2xl shadow-md p-8">
     <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "App" %></title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>


### PR DESCRIPTION
## 概要
ページタイトルを動的に表示するようにしました。

## 背景
ページごとに対応したタイトルが表示された方がUXがよいため

## 該当Issue
#61 ：タイトルを動的に表示

## 変更内容
- ページタイトルを表示するためのメソッドをapplication_helperに作成

## 確認方法
※環境構築は完了している前提
1. `http://localhost:3000` にアクセス
2. TOPページのタイトルがFigruneになっていることを確認
<img width="2142" height="1888" alt="image" src="https://github.com/user-attachments/assets/5d383931-859c-428b-8c38-71fb4436ff92" />


3. ほかのページも「〇〇 - Figrune」と表示されていることを確認
- 新規登録画面
<img width="2142" height="1888" alt="image" src="https://github.com/user-attachments/assets/add37ce1-061a-40a5-9d8b-0cce6bf73962" />

- ログイン画面
<img width="2142" height="1888" alt="image" src="https://github.com/user-attachments/assets/3018051b-c196-4760-9a9d-8cea96975f67" />

## 補足
- 特にありません。
