### PR TITLE
デプロイのため develop を main にマージ（フィギュア登録機能を追加）

### DIFF
--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -1,7 +1,35 @@
 class FiguresController < ApplicationController
   before_action :authenticate_user!
+
   def index
     @q = current_user.figures.ransack(params[:q])
     @figures = @q.result(distinct: true).order("created_at desc")
+  end
+
+  def new
+    @figure = Figure.new
+    # 初期値設定のため
+    @figure.quantity = 1
+  end
+
+  def create
+     @figure = current_user.figures.build(figure_params)
+     # 以下3点のassign_テーブル名_by_nameについて
+     # フォームで入力された名称をもとに、各関連モデルを取得（なければ作成）して Figure に紐付ける
+     @figure.assign_work_by_name(@figure.work_name)
+     @figure.assign_shop_by_name(@figure.shop_name)
+     @figure.assign_manufacture_by_name(@figure.manufacture_name)
+    if @figure.save
+      redirect_to figures_path, notice: t("defaults.flash_message.created")
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_created")
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def figure_params
+    params.require(:figure).permit(:name, :release_month, :quantity, :price, :payment_status, :size_type, :size_mm, :work_name, :shop_name, :manufacture_name, :note)
   end
 end

--- a/app/models/figure.rb
+++ b/app/models/figure.rb
@@ -1,15 +1,20 @@
 class Figure < ApplicationRecord
   validates :name, presence: true, length: { maximum: 255 }
   validates :release_month, presence: true
-  validates :quantity, presence: true
-  validates :price, presence: true
+  validates :quantity, presence: true, numericality: { greater_than_or_equal_to: 1 }
+  validates :price, presence: true, numericality: { greater_than_or_equal_to: 1 }
   validates :payment_status, presence: true
+  validates :size_mm, numericality: { greater_than_or_equal_to: 1, allow_blank: true }
   validates :note, length: { maximum: 65_535 }
 
   belongs_to :user
   belongs_to :manufacture, optional: true
   belongs_to :work, optional: true
   belongs_to :shop, optional: true
+
+  attr_accessor :work_name
+  attr_accessor :shop_name
+  attr_accessor :manufacture_name
 
   # 支払いステータス：0:未払い、1:支払い済み
   enum payment_status: { unpaid: 0, paid: 1 }
@@ -19,5 +24,25 @@ class Figure < ApplicationRecord
 
   def self.ransackable_attributes(auth_object = nil)
       [ "name" ]
+  end
+  # release_monthがXXXX-XXの形式だと保存できないためXXXX-XX-01にして回避するためのカスタムセッター
+  # Xは数値です
+  def release_month=(value)
+    super(value + "-01")
+  end
+
+  def assign_work_by_name(name)
+    return if name.blank?
+    self.work = Work.find_or_create_by(name: name)
+  end
+
+  def assign_shop_by_name(name)
+    return if name.blank?
+    self.shop = Shop.find_or_create_by(name: name)
+  end
+
+  def assign_manufacture_by_name(name)
+    return if name.blank?
+    self.manufacture = Manufacture.find_or_create_by(name: name)
   end
 end

--- a/app/views/figures/_figure.html.erb
+++ b/app/views/figures/_figure.html.erb
@@ -1,23 +1,26 @@
-<div class="flex flex-col gap-1 w-full rounded-lg border border-gray-500 px-3 py-2 hover:border-gray-400">
+<!-- 一覧画面で表示されるカード -->
+<div class="flex flex-col gap-1 w-full rounded-lg border border-gray-500 px-3 py-2">
   <div class="flex justify-between">
-    <div>
+    <!-- XXXX年XX月 発売予定 -->
+    <span>
       <%= l(figure.release_month, format: :default) %>
       <%= t("defaults.scheduled_for_release") %>
-    </div>
-    <div>
+    </span>
+    <!-- 支払いステータス -->
+    <span>
       <%= figure.payment_status_i18n %>
-    </div>
+    </span>
   </div>
+  <!-- 商品名（クリックで詳細画面へ） -->
   <div class="text-xl font-bold hover:underline">
     <%= link_to figure.name, '#' %>
   </div>
+  <!-- 金額（1個あたり）× 個数 ⇒ 合計（合計はDBに保存していない） -->
   <div>
-    <span>
-      <%= "¥#{number_with_delimiter(figure.price)}" %>
-      <%= "× #{figure.quantity}個 ⇒" %>
-      <span class="text-xl font-bold">
-        <%= "¥#{number_with_delimiter(figure.price * figure.quantity)}" %>
-      </span>  
-    </span>
+    <%= "¥#{number_with_delimiter(figure.price)}" %>
+    <%= "× #{figure.quantity}個 ⇒" %>
+    <span class="text-xl font-bold">
+      <%= "¥#{number_with_delimiter(figure.price * figure.quantity)}" %>
+    </span>  
   </div>
 </div>

--- a/app/views/figures/_form.html.erb
+++ b/app/views/figures/_form.html.erb
@@ -1,0 +1,94 @@
+<%= form_with model: figure do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="flex flex-col gap-3">
+    <!-- 商品名 -->
+    <div>
+      <%= f.label :name, class: "font-bold" %>
+      <%= f.text_field :name,
+            autofocus: true ,
+            class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+    </div>
+    <!-- 発売月 -->
+    <div>
+      <%= f.label :release_month, class: "font-bold"  %>
+      <%= f.month_field :release_month, min: Time.current,
+            class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+    </div>
+    <!-- 個数 -->
+    <div>
+      <%= f.label :quantity, class: "font-bold"  %>
+      <%= f.number_field :quantity, min: 1,
+            class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+    </div>
+    <!-- 金額 -->
+    <div>
+      <%= f.label :price, class: "font-bold"  %>
+      <%= f.number_field :price, min: 1,
+            class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+    </div>
+    <!-- 支払いステータス -->
+    <div>
+      <%= f.label :payment_status, class: "font-bold"  %>
+      <%= f.select :payment_status, Figure.payment_statuses_i18n.map { |k, v| [v, k] },
+          {}, class: "mb-3 w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+    </div>
+    <!-- 詳細情報を入力（任意）ディスクロージャー -->
+    <details class="flex flex-col gap-3 group">
+      <summary class="cursor-pointer text-sm text-gray-700 flex items-center gap-2">
+        <span class="flex-1 border-t border-solid border-gray-300"></span>
+        <span class="group-open:hidden">＋</span>
+        <span class="hidden group-open:inline">−</span>
+          <%= t("defaults.optional_details") %>
+        <span class="flex-1 border-t border-solid border-gray-300"></span>
+      </summary>
+      <div class="flex flex-col gap-3">
+        <!-- サイズ -->
+        <%= f.label :size, class: "font-bold"  %>
+        <div class="flex gap-4">
+          <!-- サイズ種別 -->
+          <div class="w-full">
+              <%= f.label :size_type , class: "text-sm" %>
+              <%= f.select :size_type, Figure.size_types_i18n.map { |k, v| [v, k] },
+                  { include_blank: t("defaults.please_select") },
+                  class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+          </div>
+          <!-- サイズ（mm） -->
+          <div class="w-full">
+              <%= f.label :size_mm, class: "text-sm" %>
+              <%= f.number_field :size_mm, min: 1,
+                  class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+          </div>
+        </div>
+        <!-- 作品名 -->
+        <div>
+          <%= f.label :work, class: "font-bold"  %>
+          <%= f.text_field :work_name,
+              class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+        </div>
+        <!-- 予約/購入店舗 -->
+        <div>
+          <%= f.label :shop, class: "font-bold"  %>
+          <%= f.text_field :shop_name,
+              class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+        </div>
+        <!-- メーカー -->
+        <div>
+          <%= f.label :manufacture, class: "font-bold"  %>
+          <%= f.text_field :manufacture_name,
+              class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+        </div>
+        <!-- 備考 -->
+        <div>
+          <%= f.label :note, class: "font-bold"  %>
+          <%= f.text_area :note,
+              class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+        </div>
+      </div>
+    </details>
+    <!-- 登録するボタン -->
+    <div class="flex justify-center">
+      <%= f.submit nil,
+            class: "mt-3 mb-16 px-18 py-2 rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/figures/_search.html.erb
+++ b/app/views/figures/_search.html.erb
@@ -1,8 +1,10 @@
 <%= search_form_for q, url: url do |f| %>
   <div class="flex my-3">
+    <!-- 検索バー -->
     <%= f.search_field :name_cont, class: "w-full rounded-lg border border-gray-500 px-3 py-2
       hover:border-gray-400", placeholder: t('defaults.search_word') %>
+    <!-- 検索ボタン -->
     <%= f.submit class: "rounded-lg border border-gray-500 px-6 py-2 
-      hover:bg-gray-500" %>
+      hover:bg-gray-200" %>
   </div>
 <% end %>

--- a/app/views/figures/index.html.erb
+++ b/app/views/figures/index.html.erb
@@ -1,11 +1,11 @@
 <% content_for(:title, t('.title')) %>
   <div class="flex flex-col max-w-6xl mx-auto items-center p-4">
-    <div class="w-full max-w-6xl rounded-2xl">
+    <div class="w-full rounded-2xl">
       <%= render 'search', q: @q, url: figures_path %>
     </div>
-      <% if @figures.present? %>
-        <%= render @figures %>
-      <% else %>
-        <span><%= t(".no_data_available") %></span>
-      <% end %>
+    <% if @figures.present? %>
+      <%= render @figures %>
+    <% else %>
+      <span><%= t(".no_data_available") %></span>
+    <% end %>
   </div>

--- a/app/views/figures/new.html.erb
+++ b/app/views/figures/new.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:title, t('.title')) %>
+  <div class="flex flex-col max-w-6xl mx-auto items-center p-4">
+    <h2 class="text-xl font-bold">
+      <%= t(".title") %>
+    </h2>
+    <div class="w-full">
+      <%= render 'form', figure: @figure %>
+    </div>
+  </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,13 +24,13 @@
       <% if key == 'notice' %>
         <div role="alert" class="border-2 bg-green-100 p-4 text-green-500">
           <div class="flex items-start gap-3">    
-            <div class="block flex-1 leading-tight font-semibold <%= key %>"><%= message %></div>
+            <div class="block flex-1 leading-tight font-semibold"><%= message %></div>
           </div>
         </div>
       <% else %>
         <div role="alert" class="border-2 bg-red-100 p-4 text-red-500">
           <div class="flex items-start gap-3">    
-            <div class="block flex-1 leading-tight font-semibold <%= key %>"><%= message %></div>
+            <div class="block flex-1 leading-tight font-semibold"><%= message %></div>
           </div>
         </div>
       <% end %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="text-red-600">
+    <ul>
+      <% object.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -16,8 +16,8 @@
                   'border-transparent text-gray-600 hover:text-gray-900'}" %>
               </li>
               <li>
-                <%= link_to '登録', '#', class: "px-2 py-1 border-b-2 transition
-                  #{current_page?('#') ?
+                <%= link_to t("header.create"), new_figure_path, class: "px-2 py-1 border-b-2 transition
+                  #{current_page?(new_figure_path) ?
                   'border-gray-900 text-gray-900 font-medium' :
                   'border-transparent text-gray-600 rounded hover:bg-gray-200 transition'}" %>
               </li>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -5,11 +5,24 @@ ja:
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "パスワード（確認）"
+      figure:
+        name: 商品名
+        release_month: 発売月
+        quantity: 個数
+        price: 金額（1個あたり）
+        payment_status: 支払いステータス
+        size: サイズ
+        size_type: サイズ種別
+        size_mm: サイズ（mm）
+        work: 作品名
+        shop: 予約/購入店舗
+        manufacture: メーカー
+        note: 備考
   enums:
     figure:
       payment_status:
         unpaid: 未払い
-        paid: 支払い済
+        paid: 支払い済み
       size_type:
         overall_height: 全高
         overall_length: 全長

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -5,8 +5,22 @@ ja:
   defaults:
     search_word: 検索内容を入力
     scheduled_for_release: 発売予定
+    optional_details: 詳細情報を入力（任意）
+    please_select: 選択してください
+    flash_message:
+      created: 登録しました
+      not_created: 登録できませんでした
+  helpers:
+    submit:
+      create: 登録する
+      submit: 保存
+      update: 更新
+  header:
+    create: 登録
   figures:
     index:
       title: ホーム
       no_data_available: 表示できるデータがありません。
+    new:
+      title: 登録
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :figures, only: [ :index ]
+  resources :figures, only: [ :index, :new, :create ]
   devise_for :users, controllers: {
     registrations: "users/registrations"
   }


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします。

## 含まれる変更
- フィギュア登録機能

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] 登録画面に行き、フィギュアの登録ができること
- [x] 必須項目に未入力があった場合とバリデーションに引っかかった場合はエラーメッセージが表示されること
- [x] 登録後は一覧表示画面に遷移すること   

## 補足
特にありません。