### PR TITLE
デプロイのため develop を main にマージ（詳細確認機能を追加）

### DIFF
--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -27,6 +27,10 @@ class FiguresController < ApplicationController
     end
   end
 
+  def show
+    @figure = Figure.find(params[:id])
+  end
+
   private
 
   def figure_params

--- a/app/models/figure.rb
+++ b/app/models/figure.rb
@@ -22,15 +22,19 @@ class Figure < ApplicationRecord
   # 大きさの単位：0:全高、1:全長
   enum size_type: { overall_height: 0, overall_length: 1 }
 
+  # Ransack で検索を許可するカラム一覧
   def self.ransackable_attributes(auth_object = nil)
       [ "name" ]
   end
+
   # release_monthがXXXX-XXの形式だと保存できないためXXXX-XX-01にして回避するためのカスタムセッター
   # Xは数値です
   def release_month=(value)
     super(value + "-01")
   end
 
+  # 以下3点のassign_テーブル名_by_nameについて
+  # フォームで入力された名称をもとに、各関連モデルを取得（なければ作成）して Figure に紐付ける
   def assign_work_by_name(name)
     return if name.blank?
     self.work = Work.find_or_create_by(name: name)
@@ -44,5 +48,10 @@ class Figure < ApplicationRecord
   def assign_manufacture_by_name(name)
     return if name.blank?
     self.manufacture = Manufacture.find_or_create_by(name: name)
+  end
+  
+  # 合計金額計算用のメソッド
+  def total_price
+    quantity * price
   end
 end

--- a/app/views/figures/_figure.html.erb
+++ b/app/views/figures/_figure.html.erb
@@ -13,7 +13,7 @@
   </div>
   <!-- 商品名（クリックで詳細画面へ） -->
   <div class="text-xl font-bold hover:underline">
-    <%= link_to figure.name, '#' %>
+    <%= link_to figure.name, figure_path(figure) %>
   </div>
   <!-- 金額（1個あたり）× 個数 ⇒ 合計（合計はDBに保存していない） -->
   <div>

--- a/app/views/figures/_form.html.erb
+++ b/app/views/figures/_form.html.erb
@@ -86,9 +86,9 @@
       </div>
     </details>
     <!-- 登録するボタン -->
-    <div class="flex justify-center">
+    <div class="max-w-sm w-full mx-auto flex flex-col">
       <%= f.submit nil,
-            class: "mt-3 mb-16 px-18 py-2 rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
+          class: "w-full mt-3 mb-10 px-18 py-2 text-center rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
     </div>
   </div>
 <% end %>

--- a/app/views/figures/_search.html.erb
+++ b/app/views/figures/_search.html.erb
@@ -1,5 +1,5 @@
 <%= search_form_for q, url: url do |f| %>
-  <div class="flex my-3">
+  <div class="flex mt-3 mb-6">
     <!-- 検索バー -->
     <%= f.search_field :name_cont, class: "w-full rounded-lg border border-gray-500 px-3 py-2
       hover:border-gray-400", placeholder: t('defaults.search_word') %>

--- a/app/views/figures/index.html.erb
+++ b/app/views/figures/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-  <div class="flex flex-col max-w-6xl mx-auto items-center p-4">
+  <div class="flex flex-col max-w-4xl mx-auto items-center p-4">
     <div class="w-full rounded-2xl">
       <%= render 'search', q: @q, url: figures_path %>
     </div>

--- a/app/views/figures/new.html.erb
+++ b/app/views/figures/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('.title')) %>
-  <div class="flex flex-col max-w-6xl mx-auto items-center p-4">
+  <div class="flex flex-col max-w-4xl mx-auto items-center p-4">
     <h2 class="text-xl font-bold">
       <%= t(".title") %>
     </h2>

--- a/app/views/figures/show.html.erb
+++ b/app/views/figures/show.html.erb
@@ -1,0 +1,92 @@
+<% content_for(:title, @figure.name) %>
+<div class="max-w-4xl mx-auto p-4">
+  <!-- 商品名 -->
+  <h2 class="text-xl font-bold text-center"><%= @figure.name %></h2>
+  <!-- 基本情報 -->
+  <h3 class="text-xl font-bold border-b-2 pb-1 mt-3">
+    <%= t(".basic_information") %>
+  </h3>
+  <dl class="my-3 divide-y divide-gray-400">
+    <!-- 支払いステータス -->
+    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".payment_status") %></dt>
+      <dd class="text-gray-700 sm:col-span-2"><%= @figure.payment_status_i18n %></dd>
+    </div>
+    <!-- 発売月 -->
+    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".release_month") %></dt>
+      <dd class="text-gray-700 sm:col-span-2"><%= l(@figure.release_month, format: :default) %></dd>
+    </div>
+    <!-- 個数-->
+    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".quantity") %></dt>
+      <dd class="text-gray-700 sm:col-span-2"><%= @figure.quantity %></dd>
+    </div>
+    <!-- 金額（1個あたり） -->
+    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".price") %></dt>
+      <dd class="text-gray-700 sm:col-span-2"><%= number_to_currency(@figure.price, unit: "¥", format: "%u%n") %></dd>
+    </div>
+    <!-- 合計金額 -->
+    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".total_price") %></dt>
+      <dd class="text-gray-700 sm:col-span-2"><%= number_to_currency(@figure.total_price, unit: "¥", format: "%u%n") %></dd>
+    </div>
+  </dl>
+  <!-- 任意入力の項目で1つでも入力されているものがあれば、詳細情報を表示する -->
+  <% if @figure.size_type.present? || @figure.size_mm.present? ||@figure.shop.present? || @figure.manufacture.present? ||
+        @figure.work.present? || @figure.note.present? %>
+    <div class="mt-6">
+      <!-- 詳細情報 -->
+      <h3 class="text-xl font-bold border-b-2 pb-1 mt-16">
+        <%= t(".optional_information") %>
+      </h3>
+      <!-- 以下のif処理は値が空白でなければ、項目と値を表示する -->
+      <dl class="my-3 divide-y divide-gray-400">
+        <% if @figure.work.present? %>
+          <!-- 作品名 -->
+          <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+            <dt class="font-bold"><%= t(".work") %></dt>
+            <dd class="text-gray-700 sm:col-span-2"><%= @figure.work.name %></dd>
+          </div>
+        <% end %>
+        <% if @figure.shop.present? %>
+          <!-- 予約/購入店舗 -->
+          <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+            <dt class="font-bold"><%= t(".shop") %></dt>
+            <dd class="text-gray-700 sm:col-span-2"><%= @figure.shop.name %></dd>
+          </div>
+        <% end %>
+        <% if @figure.manufacture.present? %>
+          <!-- メーカー -->
+          <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+            <dt class="font-bold"><%= t(".manufacture") %></dt>
+            <dd class="text-gray-700 sm:col-span-2"><%= @figure.manufacture.name %></dd>
+          </div>
+        <% end %>
+        <% if @figure.size_type? %>
+          <!-- サイズ -->
+          <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+            <dt class="font-bold"><%= t(".size") %></dt>
+            <dd class="text-gray-700 sm:col-span-2"><%= @figure.size_type_i18n %><%= "：約#{@figure.size_mm}mm" %></dd>
+          </div>
+        <% end %>
+        <% if @figure.note? %>
+          <!-- 備考 -->
+          <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+            <dt class="font-bold"><%= t(".note") %></dt>
+            <dd class="text-gray-700 sm:col-span-2"><%= @figure.note %></dd>
+          </div>
+        <% end %>
+      </dl>
+    </div>
+  <% end %>
+  <div class="max-w-sm mx-auto flex flex-col">
+    <!-- 編集するボタン -->
+    <%= link_to t(".edit"), '#',
+        class: "mt-3 mb-3 px-18 py-2 text-center rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
+    <!-- 戻るボタン -->
+    <%= link_to t(".back"), figures_path,
+        class: "mt-3 mb-10 px-18 py-2 text-center rounded-lg bg-gray-500 text-white font-semibold hover:bg-gray-600 transition" %>
+  </div>
+</div>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -23,4 +23,21 @@ ja:
       no_data_available: 表示できるデータがありません。
     new:
       title: 登録
+    show:
+      basic_information: 基本情報
+      optional_information: 詳細情報
+      name: 商品名
+      release_month: 発売月
+      quantity: 個数
+      price: 金額（1個あたり）
+      total_price: 合計金額
+      payment_status: 支払いステータス
+      size: サイズ
+      work: 作品名
+      shop: 予約/購入店舗
+      manufacture: メーカー
+      note: 備考
+      edit: 編集する
+      back: 戻る
+
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :figures, only: [ :index, :new, :create ]
+  resources :figures, only: [ :index, :new, :create, :show ]
   devise_for :users, controllers: {
     registrations: "users/registrations"
   }


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします。

## 含まれる変更
- 登録済みフィギュアの詳細確認機能の追加

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] 一覧表示画面のカード内のフィギュア名をクリックで詳細画面に遷移すること 

## 補足
- 特記事項はありません。