### PR TITLE
feat: 編集機能と編集画面の作成

### DIFF
--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -31,6 +31,32 @@ class FiguresController < ApplicationController
     @figure = Figure.find(params[:id])
   end
 
+  def edit
+    @figure = current_user.figures.find(params[:id])
+    # 以下3点の　set_仮想カラム名_from_テーブル名　について
+    # 編集画面を表示するとき、外部キーが設定されていれば、関連先テーブルのnameを取得して
+    # 仮想カラムにセットする
+    @figure.set_work_name_from_work
+    @figure.set_shop_name_from_shop
+    @figure.set_manufacturer_name_from_manufacturer
+  end
+
+  def update
+    @figure = current_user.figures.find(params[:id])
+    @figure.assign_attributes(figure_params)
+    # 以下3点のassign_テーブル名_by_nameについて
+    # フォームで入力された名称をもとに、各関連モデルを取得（なければ作成）して Figure に紐付ける
+    @figure.assign_work_by_name(@figure.work_name)
+    @figure.assign_shop_by_name(@figure.shop_name)
+    @figure.assign_manufacturer_by_name(@figure.manufacturer_name)
+    if @figure.save
+      redirect_to figure_path(@figure), notice: t("defaults.flash_message.updated")
+    else
+      flash.now[:alert] = t("defaults.flash_message.not_updated")
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def figure_params

--- a/app/models/figure.rb
+++ b/app/models/figure.rb
@@ -33,25 +33,62 @@ class Figure < ApplicationRecord
     super(value + "-01")
   end
 
-  # 以下3点のassign_テーブル名_by_nameについて
+  # 以下3点の　assign_テーブル名_by_name　について
   # フォームで入力された名称をもとに、各関連モデルを取得（なければ作成）して Figure に紐付ける
   def assign_work_by_name(name)
-    return if name.blank?
+    if name.blank?
+      self.work = nil
+      return
+    end
     self.work = Work.find_or_create_by(name: name)
   end
 
   def assign_shop_by_name(name)
-    return if name.blank?
+    if name.blank?
+      self.shop = nil
+      return
+    end
     self.shop = Shop.find_or_create_by(name: name)
   end
 
   def assign_manufacturer_by_name(name)
-    return if name.blank?
+    if name.blank?
+      self.manufacturer = nil
+      return
+    end
     self.manufacturer = Manufacturer.find_or_create_by(name: name)
   end
-  
+
   # 合計金額計算用のメソッド
   def total_price
     quantity * price
+  end
+
+  # 以下3点の　set_仮想カラム名_from_テーブル名　について
+  # 編集画面を表示するとき、外部キーが設定されていれば、関連先テーブルのnameを取得して
+  # 仮想カラムにセットする
+  def set_work_name_from_work
+    return if self.work_id.blank?
+    self.work_name = Work.find_by(id: self.work_id).name
+  end
+
+  def set_shop_name_from_shop
+    return if self.shop_id.blank?
+    self.shop_name = Shop.find_by(id: self.shop_id).name
+  end
+
+  def set_manufacturer_name_from_manufacturer
+    return if self.manufacturer_id.blank?
+    self.manufacturer_name = Manufacturer.find_by(id: self.manufacturer_id).name
+  end
+
+  # 任意項目が入力されているか
+  def optional_fields_filled?
+    size_type.present? ||
+    size_mm.present? ||
+    work_name.present? ||
+    shop_name.present? ||
+    manufacturer_name.present? ||
+    note.present?
   end
 end

--- a/app/views/figures/_form.html.erb
+++ b/app/views/figures/_form.html.erb
@@ -33,7 +33,8 @@
           {}, class: "mb-3 w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
     </div>
     <!-- 詳細情報を入力（任意）ディスクロージャー -->
-    <details class="flex flex-col gap-3 group">
+    <!-- <details <%= "open" if @figure.optional_fields_filled? %> class="flex flex-col gap-3 group">-->
+    <%= tag.details open: (@figure.optional_fields_filled?), class: "flex flex-col gap-3 group" do %>
       <summary class="cursor-pointer text-sm text-gray-700 flex items-center gap-2">
         <span class="flex-1 border-t border-solid border-gray-300"></span>
         <span class="group-open:hidden">＋</span>
@@ -84,7 +85,8 @@
               class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
         </div>
       </div>
-    </details>
+    <!-- </details> -->
+    <% end %>
     <!-- 登録するボタン -->
     <div class="max-w-sm w-full mx-auto flex flex-col">
       <%= f.submit nil,

--- a/app/views/figures/edit.html.erb
+++ b/app/views/figures/edit.html.erb
@@ -1,0 +1,14 @@
+<% content_for(:title, t('.title')) %>
+  <div class="flex flex-col max-w-4xl mx-auto items-center p-4">
+    <h2 class="text-xl font-bold">
+      <%= t(".title") %>
+    </h2>
+    <div class="w-full">
+      <%= render 'form', figure: @figure %>
+    </div>
+    <div class="w-full max-w-sm mx-auto flex flex-col">
+        <!-- 削除するボタン -->
+        <%= link_to t(".delete"), '#',
+            class: "-mt-4 mb-10 px-18 py-2 text-center rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition" %>
+    </div>
+  </div>

--- a/app/views/figures/show.html.erb
+++ b/app/views/figures/show.html.erb
@@ -83,7 +83,7 @@
   <% end %>
   <div class="max-w-sm mx-auto flex flex-col">
     <!-- 編集するボタン -->
-    <%= link_to t(".edit"), '#',
+    <%= link_to t(".edit"), edit_figure_path(@figure),
         class: "mt-3 mb-3 px-18 py-2 text-center rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
     <!-- 戻るボタン -->
     <%= link_to t(".back"), figures_path,

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -10,11 +10,13 @@ ja:
     flash_message:
       created: 登録しました
       not_created: 登録できませんでした
+      updated: 更新しました
+      not_updated: 更新できませんでした
   helpers:
     submit:
       create: 登録する
       submit: 保存
-      update: 更新
+      update: 更新する
   header:
     create: 登録
   figures:
@@ -39,5 +41,8 @@ ja:
       note: 備考
       edit: 編集する
       back: 戻る
+    edit:
+      title: 編集
+      delete: 削除する
 
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :figures, only: [ :index, :new, :create, :show ]
+  resources :figures, only: [ :index, :new, :create, :show, :edit, :update ]
   devise_for :users, controllers: {
     registrations: "users/registrations"
   }


### PR DESCRIPTION
## 概要
登録済みフィギュアの編集機能と、それに対応する画面を実装しました

## 背景
ユーザーが誤って登録した内容を、修正できるようにするため

## 該当Issue
#11 : 登録済みフィギュアの編集機能

## 変更内容
- 編集用のビューを作成
- 編集用のeditアクション、updateアクションをコントローラーに追加

## 確認方法
※環境構築は完了している & ログインしている前提
1. 一覧表示画面から編集する任意のフィギュアをクリックする
2. `編集する`ボタンをクリック
3. 項目を編集後、`更新する`ボタンをクリックする
<img width="2142" height="1886" alt="スクリーンショット 2026-01-18 134320" src="https://github.com/user-attachments/assets/086fdbb9-aa57-47a8-bce7-06648378c307" />

4. 編集した内容が反映されていることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/aad20dda-e8cd-4a06-adc2-0e4b94aa9fb1" />

5. 必須項目で空欄がある場合、エラーメッセージが表示されることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/cfa2c853-1ae2-4ee6-8f6c-827749261dee" />

6. 任意項目は空欄で更新ができることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/1ceda1eb-ef57-4a2b-83f7-d75fd94e642c" />
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/2c31956f-2611-4ccb-b762-e13cab6b349f" />

## 補足
- 前回記載したプルリクの確認方法がQAテスト並みの細かさだったため、少し簡素化しました。