### PR TITLE
feat: 削除機能の実装

### DIFF
--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -57,6 +57,12 @@ class FiguresController < ApplicationController
     end
   end
 
+  def destroy
+    figure = current_user.figures.find(params[:id])
+    figure.destroy!
+    redirect_to figures_path, notice: t("defaults.flash_message.deleted"), status: :see_other
+  end
+
   private
 
   def figure_params

--- a/app/views/figures/edit.html.erb
+++ b/app/views/figures/edit.html.erb
@@ -7,8 +7,8 @@
       <%= render 'form', figure: @figure %>
     </div>
     <div class="w-full max-w-sm mx-auto flex flex-col">
-        <!-- 削除するボタン -->
-        <%= link_to t(".delete"), '#',
-            class: "-mt-4 mb-10 px-18 py-2 text-center rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition" %>
+      <!-- 削除するボタン -->
+      <%= link_to t(".delete"), figure_path(@figure), data: { turbo_method: :delete, turbo_confirm: t("defaults.delete_confirm") },
+          class: "-mt-4 mb-10 px-18 py-2 text-center rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition" %>
     </div>
   </div>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -7,11 +7,13 @@ ja:
     scheduled_for_release: 発売予定
     optional_details: 詳細情報を入力（任意）
     please_select: 選択してください
+    delete_confirm: 本当に削除してよろしいですか？
     flash_message:
       created: 登録しました
       not_created: 登録できませんでした
       updated: 更新しました
       not_updated: 更新できませんでした
+      deleted: 削除しました
   helpers:
     submit:
       create: 登録する

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :figures, only: [ :index, :new, :create, :show, :edit, :update ]
+  resources :figures, only: [ :index, :new, :create, :show, :edit, :update, :destroy ]
   devise_for :users, controllers: {
     registrations: "users/registrations"
   }


### PR DESCRIPTION
## 概要
フィギュアの削除機能を実装しました

## 背景
誤って登録したデータや不要になったデータを削除できるようにし、UXを向上させるため

## 該当Issue
#12 : 登録済みフィギュアの削除機能

## 変更内容
- 削除用のdestroyアクションをコントローラーに追加

## 確認方法
※環境構築は完了している & ログインしている前提
1. 一覧表示画面から任意のフィギュアをクリックする
2. `編集する`ボタンをクリック
3. `削除する`ボタンをクリックする
4. 削除確認モーダルで`OK`をクリック
5. 該当のフィギュアが削除されていることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/8e0646ca-b702-4a69-adfd-cd49f0b9106a" />

## 補足
- 特記事項はございません。