### PR TITLE
デプロイのため develop を main にマージ（アカウント設定ページを追加）

### DIFF
--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -1,0 +1,3 @@
+class AccountSettingsController < ApplicationController
+def show; end
+end

--- a/app/helpers/account_settings_helper.rb
+++ b/app/helpers/account_settings_helper.rb
@@ -1,0 +1,2 @@
+module AccountSettingsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :confirmable
 
   has_many :figures
+
+  # 通知のタイミング：0:通知なし、1:1週間前、2:2週間前、3:3週間前、4:1か月前、 5:2か月前
+  # enum email_notification_timing: { disabled: 0, one_week_before: 1, two_week_before: 2, three_week_before: 3, one_month_before: 4, two_month_before: 5 }
 end

--- a/app/views/account_settings/show.html.erb
+++ b/app/views/account_settings/show.html.erb
@@ -1,0 +1,38 @@
+<% content_for(:title, t('.title')) %>
+<div class="max-w-4xl mx-auto p-4">
+  <!-- アカウント設定（タイトル） -->
+  <h2 class="text-xl font-bold text-center"><%= t('.title') %></h2>
+  <!-- 個人情報設定 -->
+  <h3 class="text-xl font-bold border-b-2 pb-1 mt-3">
+    <%= t(".personal_information_setting") %>
+  </h3>
+  <dl class="my-3 divide-y divide-gray-400">
+    <!-- メールアドレス変更 -->
+    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".change_email") %></dt>
+      <dd class="text-gray-700 sm:col-span-2"><%= link_to t('.change'), '#', class: "text-blue-500 hover:underline font-medium"%></dd>
+    </div>
+    <!-- パスワード変更 -->
+    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".change_password") %></dt>
+      <dd class="text-gray-700 sm:col-span-2"><%= link_to t('.change'), '#', class: "text-blue-500 hover:underline font-medium"%></dd>
+    </div>
+  </dl>
+  <!-- 通知設定 -->
+  <h3 class="text-xl font-bold border-b-2 pb-1 mt-12">
+    <%= t(".notification_setting") %>
+  </h3>
+  <dl class="my-3 divide-y divide-gray-400">
+    <!-- メール通知 -->
+    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".email_notification") %></dt>
+      <!-- ↓はセレクトボックスの予定 -->
+      <dd class="text-gray-700 sm:col-span-2"><%= '通知なし' %></dd>
+    </div>
+  </dl>
+  <div class="max-w-sm mx-auto flex flex-col">
+    <!-- 戻るボタン -->
+    <%= link_to t(".back"), figures_path,
+        class: "mt-3 mb-10 px-18 py-2 text-center rounded-lg bg-gray-500 text-white font-semibold hover:bg-gray-600 transition" %>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -28,6 +28,12 @@
                   'border-transparent text-gray-600 rounded hover:bg-gray-200 transition'}" %>
               </li>
               <li>
+                <%= link_to 'アカウント設定', account_setting_path, class: "px-2 py-1 border-b-2 transition
+                  #{current_page?(account_setting_path) ?
+                  'border-gray-900 text-gray-900 font-medium' :
+                  'border-transparent text-gray-600 rounded hover:bg-gray-200 transition'}" %>
+              </li>
+              <li>
                 <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: "px-2 py-1 border-b-2 transition
                   border-transparent text-gray-600 rounded hover:bg-gray-200 transition" %>
               </li>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -46,5 +46,15 @@ ja:
     edit:
       title: 編集
       delete: 削除する
+  account_settings:
+    show:
+      title: アカウント設定
+      personal_information_setting: 個人情報設定
+      change_email: メールアドレス変更
+      change_password: パスワード変更
+      change: 変更
+      notification_setting: 通知設定
+      email_notification: メール通知
+      back: 戻る
 
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   resources :figures, only: [ :index, :new, :create, :show, :edit, :update, :destroy ]
+  resource :account_setting, only: [ :show ]
   devise_for :users, controllers: {
     registrations: "users/registrations"
   }

--- a/test/controllers/account_settings_controller_test.rb
+++ b/test/controllers/account_settings_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AccountSettingsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします。

## 含まれる変更
- アカウント設定ページの追加

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] ヘッダーの`アカウント設定`をクリックでアカウント設定ページが表示されること

## 補足
- まだパスワードの変更、メールアドレスの変更、メール通知の設定はできません。