### PR TITLE
デプロイのため develop を main にマージ（ドメインを追加）

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,10 +96,9 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts << "figrune-app.com"
+  config.hosts << "www.figrune-app.com"
+  config.hosts << "figrune.onrender.com"
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- 独自ドメインの設定

## 動作確認
- [x] 既存の機能に問題がないこと

## 補足
- 本プルリク後に独自ドメインでサイトに接続確認をする予定です