### PR TITLE
feat: パスワード再設定画面を作成しました

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,41 @@
-<h2>Change your password</h2>
+<% content_for(:title, t('.title')) %>
+<div class="min-h-screen flex items-center justify-center px-4">
+  <div class="w-full max-w-md bg-gray-100 rounded-2xl shadow-md p-8">
+    <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">
+      <%= t(".title") %>
+    </h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-5" }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <!-- パスワード -->
+      <div>
+        <%= f.label :password, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <% if @minimum_password_length %>
+          <p class="text-xs text-gray-500 mb-1">
+            <%= t(".password_hint", min: @minimum_password_length) %>
+          </p>
+        <% end %>
+        <%= f.password_field :password,
+          autofocus: true,
+          autocomplete: "new-password",
+          class: "w-full rounded-lg border border-gray-300 bg-white px-3 py-2 hover:border-gray-400" %>
+      </div>
+
+      <!-- パスワード確認 -->
+      <div>
+        <%= f.label :password_confirmation, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.password_field :password_confirmation,
+          autocomplete: "new-password",
+          class: "w-full rounded-lg border border-gray-300 bg-white px-3 py-2 hover:border-gray-400" %>
+      </div>
+
+      <!-- 送信するボタン -->
+      <div>
+        <%= f.submit t(".submit"),
+          class: "w-full py-2.5 rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
+      </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/config/locales/devise.view.ja.yml
+++ b/config/locales/devise.view.ja.yml
@@ -15,8 +15,13 @@ ja:
         dont_have_account: まだアカウントをお持ちでない方はこちら
         forgot_password: パスワードをお忘れの方はこちら
     passwords:
+      no_token: パスワード再設定リンクが無効か期限切れです。新しいメールを送信してください。
       new:
         title: パスワード再設定
         describe_html: 会員登録をしたメールアドレスを入力し、「送信する」ボタンをクリックしてください。<br>入力されたメールアドレスに確認メールを送信します。
         submit: 送信する
         back_to_login: 戻る
+      edit:
+        title: パスワード再設定
+        password_hint: "※%{min}文字以上"
+        submit: 変更する


### PR DESCRIPTION
## 概要
パスワード再設定画面を作成しました

## 背景
deviseのデフォルトデザインをアプリ全体のUIに合わせるため

## 該当Issue
#15 : パスワードリセットページの作成

## 変更内容
- パスワード再設定画面用のビューを変更

## 確認方法
※環境構築は完了している前提
1. ログイン画面にて`パスワードをお忘れの方はこちら`をクリックする
2. メールアドレスを入力して`送信する`をクリックする
3. 受信したメール内のURLをクリックする
4. パスワード再設定画面が表示されることを確認
<img width="2160" height="1884" alt="image" src="https://github.com/user-attachments/assets/c7d07956-8bbf-4be9-82a1-3622a8b5a81f" />

## 補足
- パスワードリセットのロジックはdeviseに組み込まれているため実装済みです
- パスワードがリセットされることも確認済みです