### PR TITLE
デプロイのため develop を main にマージ（メール通知項目を追加）

### DIFF
--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -1,5 +1,7 @@
 class AccountSettingsController < ApplicationController
-  def show; end
+  def show
+    @user = current_user
+  end
 
   def edit_email
     @user = current_user
@@ -41,6 +43,16 @@ class AccountSettingsController < ApplicationController
     end
   end
 
+  def update_email_notification_timing
+    @user = current_user
+    if @user.update(email_notification_timing_params)
+      render :show
+    else
+      flash.now[:alert] = t("defaults.flash_message.account_setting.not_updated")
+      render :show, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def email_params
@@ -49,5 +61,9 @@ class AccountSettingsController < ApplicationController
 
   def password_params
     params.require(:user).permit(:current_password, :password, :password_confirmation)
+  end
+
+  def email_notification_timing_params
+    params.require(:user).permit(:email_notification_timing)
   end
 end

--- a/app/javascript/controllers/auto_submit_controller.js
+++ b/app/javascript/controllers/auto_submit_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  submit() {
+    // フォームを送信
+    this.element.requestSubmit()
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import AutoSubmitController from "./auto_submit_controller"
+application.register("auto-submit", AutoSubmitController)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,5 +7,5 @@ class User < ApplicationRecord
   has_many :figures
 
   # 通知のタイミング：0:通知なし、1:1週間前、2:2週間前、3:3週間前、4:1か月前、 5:2か月前
-  # enum email_notification_timing: { disabled: 0, one_week_before: 1, two_week_before: 2, three_week_before: 3, one_month_before: 4, two_month_before: 5 }
+  enum email_notification_timing: { disabled: 0, one_week_before: 1, two_week_before: 2, three_week_before: 3, one_month_before: 4, two_month_before: 5 }
 end

--- a/app/views/account_settings/_email_notification_form.html.erb
+++ b/app/views/account_settings/_email_notification_form.html.erb
@@ -1,0 +1,15 @@
+<%= turbo_frame_tag "email_notification" do %>
+  <%= form_with model: @user, 
+                url: update_email_notification_timing_account_setting_path, 
+                method: :patch,
+                data: { controller: "auto-submit" } do |f| %>
+    
+    <div class="form-group">
+      <%= f.select :email_notification_timing,
+                   User.email_notification_timings_i18n.map { |k, v| [v, k] },
+                   {}, 
+                   class: "p-1 border",
+                   data: { action: "change->auto-submit#submit" } %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/account_settings/show.html.erb
+++ b/app/views/account_settings/show.html.erb
@@ -8,12 +8,12 @@
   </h3>
   <dl class="my-3 divide-y divide-gray-400">
     <!-- メールアドレス変更 -->
-    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+    <div class="grid grid-cols-2 py-3 sm:grid-cols-3">
       <dt class="font-bold"><%= t(".change_email") %></dt>
       <dd class="text-gray-700 sm:col-span-2"><%= link_to t('.change'), edit_email_account_setting_path, class: "text-blue-500 hover:underline font-medium"%></dd>
     </div>
     <!-- パスワード変更 -->
-    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+    <div class="grid grid-cols-2 py-3 sm:grid-cols-3">
       <dt class="font-bold"><%= t(".change_password") %></dt>
       <dd class="text-gray-700 sm:col-span-2"><%= link_to t('.change'), edit_password_account_setting_path, class: "text-blue-500 hover:underline font-medium"%></dd>
     </div>
@@ -24,10 +24,12 @@
   </h3>
   <dl class="my-3 divide-y divide-gray-400">
     <!-- メール通知 -->
-    <div class="grid grid-cols-1 py-3 sm:grid-cols-3">
+    <div class="grid grid-cols-2 py-3 items-center sm:grid-cols-3">
       <dt class="font-bold"><%= t(".email_notification") %></dt>
       <!-- ↓はセレクトボックスの予定 -->
-      <dd class="text-gray-700 sm:col-span-2"><%= '通知なし' %></dd>
+      <dd class="text-gray-700 sm:col-span-2">
+        <%= render 'account_settings/email_notification_form' %>
+      </dd>
     </div>
   </dl>
   <div class="max-w-sm mx-auto flex flex-col">

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -19,6 +19,14 @@ ja:
         manufacturer: メーカー
         note: 備考
   enums:
+    user:
+      email_notification_timing:
+        disabled: 通知なし
+        one_week_before: 1週間前
+        two_week_before: 2週間前
+        three_week_before: 3週間前
+        one_month_before: 1ヶ月前
+        two_month_before: 2ヶ月前
     figure:
       payment_status:
         unpaid: 未払い

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     patch :update_email
     get   :edit_password
     patch :update_password
+    patch :update_email_notification_timing
   end
   devise_for :users, controllers: {
     registrations: "users/registrations",

--- a/db/migrate/20260125055337_add_email_notification_timing_to_users.rb
+++ b/db/migrate/20260125055337_add_email_notification_timing_to_users.rb
@@ -1,0 +1,5 @@
+class AddEmailNotificationTimingToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :EmailNotificationTiming, :integer, default: 4, null: false
+  end
+end

--- a/db/migrate/20260125063739_rename_email_notification_timing_in_users.rb
+++ b/db/migrate/20260125063739_rename_email_notification_timing_in_users.rb
@@ -1,0 +1,5 @@
+class RenameEmailNotificationTimingInUsers < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :users, :EmailNotificationTiming, :email_notification_timing
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_17_045103) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_25_063739) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -59,6 +59,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_17_045103) do
     t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "email_notification_timing", default: 4, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- アカウント設定画面のメール通知項目

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] メール通知のセレクトボックスを変化させることで非同期で値が保存されること

## 補足
- メール通知のセレクトボックスを参照してメール送信するロジックは未実装です