### PR TITLE
デプロイのため develop を main にマージ（メール通知機能を追加）

### DIFF
--- a/.github/workflows/figure_payment_notification.yml
+++ b/.github/workflows/figure_payment_notification.yml
@@ -1,0 +1,37 @@
+name: figure_payment_notification
+
+on:
+  schedule:
+    # 毎日9:00に実行（UTC時間のため0 0に設定）
+    - cron: '0 0 * * *'
+  workflow_dispatch: # 手動実行も可能
+
+jobs:
+  run-rake-task:
+    runs-on: ubuntu-latest
+
+    env:
+      RAILS_ENV: production
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      MAIL_FROM: ${{ secrets.MAIL_FROM }}
+    
+    steps:
+      # GithubActionsの仮想環境用のディレクトリにリポジトリのクローン
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Rubyのセットアップ
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.10'
+          bundler-cache: true
+
+      # gemのインストール
+      - name: Install dependencies
+        run: bundle install
+
+      # rakeタスクの実行   
+      - name: Run Rake Task
+        run: bundle exec rake reminders:figure_payment_notification

--- a/app/mailers/figure_mailer.rb
+++ b/app/mailers/figure_mailer.rb
@@ -1,0 +1,14 @@
+# app/mailers/notification_mailer.rb
+class FigureMailer < ApplicationMailer
+  def monthly_payment_summary(user, figures, release_month, total_price)
+    @user = user
+    @figures = figures
+    @month_date = release_month
+    @total_price = total_price
+
+    mail(
+      to: user.email,
+      subject: "【Figrune】#{release_month.strftime('%Y年%-m月')}の発売予定フィギュア"
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,25 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
 
-  has_many :figures
+  has_many :figures, dependent: :destroy
 
   # 通知のタイミング：0:通知なし、1:1週間前、2:2週間前、3:3週間前、4:1か月前、 5:2か月前
   enum email_notification_timing: { disabled: 0, one_week_before: 1, two_week_before: 2, three_week_before: 3, one_month_before: 4, two_month_before: 5 }
+
+  def notification_date_for(month_date)
+    case email_notification_timing
+    when "one_week_before"
+      month_date - 1.week
+    when "two_week_before"
+      month_date - 2.weeks
+    when "three_week_before"
+      month_date - 3.weeks
+    when "one_month_before"
+      month_date - 1.month
+    when "two_month_before"
+      month_date - 2.months
+    else
+      nil
+    end
+  end
 end

--- a/app/views/figure_mailer/monthly_payment_summary.html.erb
+++ b/app/views/figure_mailer/monthly_payment_summary.html.erb
@@ -1,0 +1,17 @@
+<p>Figruneをいつもご利用いただきありがとうございます。</p>
+
+<p><%= @month_date.strftime("%Y年%-m月") %> 発売予定のフィギュアのお知らせです。</p>
+
+<% @figures.each do |figure| %>
+  <% if figure.payment_status == 'unpaid' %>
+    <p>・<%= figure.name %>（<%= figure.payment_status_i18n %>）：<%= number_to_currency(figure.price) %> × <%= figure.quantity %>個</p>
+  <% else %>
+    <p>・<%= figure.name %>（<%= figure.payment_status_i18n %>）：<%= number_to_currency(figure.price) %> × <%= figure.quantity %>個</p>
+  <% end %>
+<% end %>
+
+<p>お支払い予定の合計金額：<strong><%= number_to_currency(@total_price) %></strong></p>
+
+<p>※ 支払い済みのフィギュアの金額は合計金額に含まれていません。</p>
+
+<p>Figrune</p>

--- a/lib/tasks/figure_payment_notification.rake
+++ b/lib/tasks/figure_payment_notification.rake
@@ -1,0 +1,22 @@
+namespace :reminders do
+  desc "フィギュアの月別支払い合計額をメール通知"
+  task figure_payment_notification: :environment do
+    today = Date.current
+
+    User.includes(:figures).find_each do |user|
+      # 今月以降に発売予定のフィギュアを取得
+      upcoming_figures = user.figures.select { |figure| figure.release_month >= today.beginning_of_month }
+      # フィギュアをハッシュ（release_month => [Figure1...]）で発売月ごとにまとめる
+      figures_grouped_by_release_month = upcoming_figures.group_by(&:release_month)
+      figures_grouped_by_release_month.each do |release_month, figures|
+        # 今日が通知タイミングか確かめる
+        next unless user.notification_date_for(release_month) == today
+        # 未払いのフィギュアだけをフィルタリング
+        unpaid_figures = figures.select(&:unpaid?)
+        # 未払いのフィギュアの金額合計
+        total_price = unpaid_figures.sum { |figure| figure.price * figure.quantity }
+        FigureMailer.monthly_payment_summary(user, figures, release_month, total_price).deliver_now
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- メール通知機能

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] 登録済みフィギュアの発売月ー指定したメール通知の期間の日にメール通知がくること

## 補足
- 定期実行はGithubActionsで実行しております