### PR TITLE
chore: GithubActionsのworkflowsを修正

### DIFF
--- a/.github/workflows/figure_payment_notification.yml
+++ b/.github/workflows/figure_payment_notification.yml
@@ -15,6 +15,7 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       MAIL_FROM: ${{ secrets.MAIL_FROM }}
+      SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
     
     steps:
       # GithubActionsの仮想環境用のディレクトリにリポジトリのクローン


### PR DESCRIPTION
## 概要
GithubActionsのworkflowsを修正しました

## 背景
SECRET_KEY_BASEが見当たらない旨のエラーが出たため

## 該当Issue
#111 : GithubActionsのエラー修正

## 変更内容
- workflowを修正

## 確認方法
- デプロイ後に確認します

## 補足
- 特記事項はございません