### PR TITLE
デプロイのため develop を main にマージ（GithubActionsのworkflowsにSECRET_KEY_BASEを追加）

### DIFF
--- a/.github/workflows/figure_payment_notification.yml
+++ b/.github/workflows/figure_payment_notification.yml
@@ -15,6 +15,7 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       MAIL_FROM: ${{ secrets.MAIL_FROM }}
+      SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
     
     steps:
       # GithubActionsの仮想環境用のディレクトリにリポジトリのクローン


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- GithubActionsのworkflowsにSECRET_KEY_BASEを追加

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] 登録済みフィギュアの発売月 ー 指定したメール通知の期間の日にメール通知がくること

## 補足
- 特記事項はございません