### PR TITLE
デプロイのため develop を main にマージ（一覧表示画面での並び替え機能を追加）

### DIFF
--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -14,6 +14,7 @@ class FiguresController < ApplicationController
 
   def create
      @figure = current_user.figures.build(figure_params)
+     @figure.calculate_total_price
      # 以下3点のassign_テーブル名_by_nameについて
      # フォームで入力された名称をもとに、各関連モデルを取得（なければ作成）して Figure に紐付ける
      @figure.assign_work_by_name(@figure.work_name)
@@ -44,6 +45,7 @@ class FiguresController < ApplicationController
   def update
     @figure = current_user.figures.find(params[:id])
     @figure.assign_attributes(figure_params)
+    @figure.calculate_total_price
     # 以下3点のassign_テーブル名_by_nameについて
     # フォームで入力された名称をもとに、各関連モデルを取得（なければ作成）して Figure に紐付ける
     @figure.assign_work_by_name(@figure.work_name)

--- a/app/models/figure.rb
+++ b/app/models/figure.rb
@@ -24,7 +24,7 @@ class Figure < ApplicationRecord
 
   # Ransack で検索を許可するカラム一覧
   def self.ransackable_attributes(auth_object = nil)
-      [ "name" ]
+      [ "name", "release_month", "created_at", "total_price" ]
   end
 
   # release_monthがXXXX-XXの形式だと保存できないためXXXX-XX-01にして回避するためのカスタムセッター
@@ -57,6 +57,11 @@ class Figure < ApplicationRecord
       return
     end
     self.manufacturer = Manufacturer.find_or_create_by(name: name)
+  end
+
+  def calculate_total_price
+    return if self.price.blank? || self.quantity.blank?
+    self.total_price = self.price * self.quantity
   end
 
   # 合計金額計算用のメソッド

--- a/app/views/figures/_sort.html.erb
+++ b/app/views/figures/_sort.html.erb
@@ -1,0 +1,24 @@
+<%= search_form_for q, url: url do |f| %>
+  <!-- 既存の検索条件を保持 -->
+  <%= f.hidden_field :name_cont %>
+  
+  <div class="flex items-center gap-2">
+    <label><%= t('.sort') %></label>
+    <%= f.select :s, 
+      [
+        [t('figures.sort.created_at_desc'), 'created_at desc'],
+        [t('figures.sort.created_at_asc'), 'created_at asc'],
+        [t('figures.sort.release_month_asc'), 'release_month asc'],
+        [t('figures.sort.release_month_desc'), 'release_month desc'],
+        [t('figures.sort.total_price_asc'), 'total_price asc'],
+        [t('figures.sort.total_price_desc'), 'total_price desc']
+      ],
+      # セレクトボックスで選択した値を保持する
+      { selected: params.dig(:q, :s) || 'created_at desc' },
+      {
+        class: "rounded-lg border border-gray-500 px-3 py-2 hover:border-gray-400",
+        onchange: "this.form.submit();"
+      }
+    %>
+  </div>
+<% end %>

--- a/app/views/figures/index.html.erb
+++ b/app/views/figures/index.html.erb
@@ -1,9 +1,12 @@
 <% content_for(:title, t('.title')) %>
   <div class="flex flex-col max-w-4xl mx-auto items-center p-4">
-    <div class="w-full rounded-2xl">
+    <div class="w-full">
       <%= render 'search', q: @q, url: figures_path %>
     </div>
     <% if @figures.present? %>
+      <div class="flex w-full justify-end pb-3">
+        <%= render 'sort', q: @q, url: figures_path %>
+      </div>
       <%= render @figures %>
     <% else %>
       <span><%= t(".no_data_available") %></span>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -82,6 +82,14 @@ ja:
     edit:
       title: 編集
       delete: 削除する
+    sort:
+      sort: 並び替え
+      created_at_desc: 登録日（新しい順）
+      created_at_asc: 登録日（古い順）
+      release_month_asc: 発売月（早い順）
+      release_month_desc: 発売月（遅い順）
+      total_price_asc: 合計金額（安い順）
+      total_price_desc: 合計金額（高い順）
   account_settings:
     show:
       title: アカウント設定

--- a/db/migrate/20260127142723_add_total_price_to_figures.rb
+++ b/db/migrate/20260127142723_add_total_price_to_figures.rb
@@ -1,0 +1,5 @@
+class AddTotalPriceToFigures < ActiveRecord::Migration[7.2]
+  def change
+    add_column :figures, :total_price, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_25_063739) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_27_142723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,6 +29,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_25_063739) do
     t.bigint "shop_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "total_price", default: 0, null: false
     t.index ["manufacturer_id"], name: "index_figures_on_manufacturer_id"
     t.index ["shop_id"], name: "index_figures_on_shop_id"
     t.index ["user_id"], name: "index_figures_on_user_id"


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- `Figure`テーブルに`total_price`カラムの追加
- `Figure`コントローラーの`create`、`update`アクションに`total_price`を計算する処理を追加
- 一覧表示画面内の並び替え機能

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] 並び替えが機能していること

## 補足
- 現時点では`Figure.rb`内の`total_price`メソッドは使用してます