### PR TITLE
デプロイのため develop を main にマージ（オートコンプリートの機能を追加）

### DIFF
--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -65,6 +65,34 @@ class FiguresController < ApplicationController
     redirect_to figures_path, notice: t("defaults.flash_message.deleted"), status: :see_other
   end
 
+  def autocomplete
+    @figures = current_user.figures.select(:name).distinct.where("name like ?", "%#{params[:q]}%")
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  def autocomplete_work
+    @works = Work.joins(:figures).where(figures: { user_id: current_user.id }).where("works.name LIKE ?", "%#{params[:q]}%").distinct
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  def autocomplete_shop
+    @shops = Shop.joins(:figures).where(figures: { user_id: current_user.id }).where("shops.name LIKE ?", "%#{params[:q]}%").distinct
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  def autocomplete_manufacturer
+    @manufacturers = Manufacturer.joins(:figures).where(figures: { user_id: current_user.id }).where("manufacturers.name LIKE ?", "%#{params[:q]}%").distinct
+    respond_to do |format|
+      format.js
+    end
+  end
+
   private
 
   def figure_params

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,6 +1,8 @@
 import { Application } from "@hotwired/stimulus"
+import { Autocomplete } from "stimulus-autocomplete"
 
 const application = Application.start()
+application.register("autocomplete", Autocomplete)
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/views/figures/_form.html.erb
+++ b/app/views/figures/_form.html.erb
@@ -61,22 +61,43 @@
           </div>
         </div>
         <!-- 作品名 -->
-        <div>
+        <div data-controller="autocomplete" data-autocomplete-url-value="/figures/autocomplete_work" role="combobox">
           <%= f.label :work, class: "font-bold"  %>
           <%= f.text_field :work_name,
+              data: { autocomplete_target: 'input' },
               class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+          <%= f.hidden_field :work_id, data: { autocomplete_target: 'hidden' } %>
+          <!-- オートコンプリート候補 -->
+          <div class="relative flex">
+            <ul class="list-group absolute w-full rounded-md border divide-y divide-gray-400 bg-white empty:hidden overflow-hidden"
+                data-autocomplete-target="results"></ul>
+          </div>
         </div>
         <!-- 予約/購入店舗 -->
-        <div>
+        <div data-controller="autocomplete" data-autocomplete-url-value="/figures/autocomplete_shop" role="combobox">
           <%= f.label :shop, class: "font-bold"  %>
           <%= f.text_field :shop_name,
+              data: { autocomplete_target: 'input' },
               class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+          <%= f.hidden_field :shop_id, data: { autocomplete_target: 'hidden' } %>
+          <!-- オートコンプリート候補 -->
+          <div class="relative flex">
+            <ul class="list-group absolute w-full rounded-md border divide-y divide-gray-400 bg-white empty:hidden overflow-hidden"
+                data-autocomplete-target="results"></ul>
+          </div>
         </div>
         <!-- メーカー -->
-        <div>
+        <div data-controller="autocomplete" data-autocomplete-url-value="/figures/autocomplete_manufacturer" role="combobox">
           <%= f.label :manufacturer, class: "font-bold"  %>
           <%= f.text_field :manufacturer_name,
+              data: { autocomplete_target: 'input' },
               class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
+          <%= f.hidden_field :manufacturer_id, data: { autocomplete_target: 'hidden' } %>
+          <!-- オートコンプリート候補 -->
+          <div class="relative flex">
+            <ul class="list-group absolute w-full rounded-md border divide-y divide-gray-400 bg-white empty:hidden overflow-hidden"
+                data-autocomplete-target="results"></ul>
+          </div>
         </div>
         <!-- 備考 -->
         <div>

--- a/app/views/figures/_search.html.erb
+++ b/app/views/figures/_search.html.erb
@@ -1,10 +1,18 @@
 <%= search_form_for q, url: url do |f| %>
   <div class="flex mt-3 mb-6">
-    <!-- 検索バー -->
-    <%= f.search_field :name_cont, class: "w-full rounded-lg border border-gray-500 px-3 py-2
-      hover:border-gray-400", placeholder: t('defaults.search_word') %>
+    <div class="w-full" data-controller="autocomplete" data-autocomplete-url-value="/figures/autocomplete" role="combobox">
+      <!-- 検索バー -->
+      <%= f.search_field :name_cont,
+        data: { autocomplete_target: 'input' },
+        class: "w-full rounded-lg border border-gray-500 px-3 py-2 hover:border-gray-400", 
+        placeholder: t('defaults.search_word')%>
+      <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
+      <!-- オートコンプリート候補 -->
+      <div class="relative flex">
+        <ul class="list-group absolute w-full rounded-md border divide-y divide-gray-400 bg-white empty:hidden overflow-hidden" data-autocomplete-target="results"></ul>
+      </div>
+    </div>
     <!-- 検索ボタン -->
-    <%= f.submit class: "rounded-lg border border-gray-500 px-6 py-2 
-      hover:bg-gray-200" %>
+    <%= f.submit class: "rounded-lg border border-gray-500 px-6 py-2 hover:bg-gray-200" %>
   </div>
 <% end %>

--- a/app/views/figures/autocomplete.html.erb
+++ b/app/views/figures/autocomplete.html.erb
@@ -1,0 +1,6 @@
+<% @figures.each do |figure| %>
+  <li class="py-2 px-3 hover:bg-blue-200 aria-selected:bg-blue-200"
+      role="option" data-autocomplete-value="<%= figure.id %>" data-autocomplete-label="<%= figure.name %>">
+    <%= figure.name %>
+  </li>
+<% end %>

--- a/app/views/figures/autocomplete_manufacturer.html.erb
+++ b/app/views/figures/autocomplete_manufacturer.html.erb
@@ -1,0 +1,6 @@
+<% @manufacturers.each do |manufacturer| %>
+  <li class="py-2 px-3 hover:bg-blue-200 aria-selected:bg-blue-200"
+      role="option" data-autocomplete-value="<%= manufacturer.id %>" data-autocomplete-label="<%= manufacturer.name %>">
+    <%= manufacturer.name %>
+  </li>
+<% end %>

--- a/app/views/figures/autocomplete_shop.html.erb
+++ b/app/views/figures/autocomplete_shop.html.erb
@@ -1,0 +1,6 @@
+<% @shops.each do |shop| %>
+  <li class="py-2 px-3 hover:bg-blue-200 aria-selected:bg-blue-200"
+      role="option" data-autocomplete-value="<%= shop.id %>" data-autocomplete-label="<%= shop.name %>">
+    <%= shop.name %>
+  </li>
+<% end %>

--- a/app/views/figures/autocomplete_work.html.erb
+++ b/app/views/figures/autocomplete_work.html.erb
@@ -1,0 +1,6 @@
+<% @works.each do |work| %>
+  <li class="py-2 px-3 hover:bg-blue-200 aria-selected:bg-blue-200"
+      role="option" data-autocomplete-value="<%= work.id %>" data-autocomplete-label="<%= work.name %>">
+    <%= work.name %>
+  </li>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
-  resources :figures, only: [ :index, :new, :create, :show, :edit, :update, :destroy ]
+  resources :figures, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
+    get :autocomplete, on: :collection
+    get :autocomplete_work, on: :collection
+    get :autocomplete_shop, on: :collection
+    get :autocomplete_manufacturer, on: :collection
+  end
   resource :account_setting, only: [ :show ] do
     get   :edit_email
     patch :update_email

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.20",
     "@tailwindcss/cli": "^4.1.18",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwindcss": "^4.1.18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,6 +632,11 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 tailwindcss@4.1.18, tailwindcss@^4.1.18:
   version "4.1.18"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-4.1.18.tgz#f488ba47853abdb5354daf9679d3e7791fc4f4e3"


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- 一覧画面の検索フィールドにオートコンプリートの実装
- 登録、編集画面の作品名、予約/購入店舗、メーカーにオートコンプリートの実装

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] 検索フィールドの下にオートコンプリートの候補が表示されること
- [x] 作品名、予約/購入店舗、メーカー欄の下にオートコンプリートの候補が表示されること 

## 補足
- 候補は既存データをもとに表示されます