### PR TITLE
style: 一覧画面のフィギュアの枠線のCSSを修正

### DIFF
--- a/app/views/figures/_figure.html.erb
+++ b/app/views/figures/_figure.html.erb
@@ -1,5 +1,5 @@
 <!-- 一覧画面で表示されるカード -->
-<div class="flex flex-col gap-1 w-full rounded-lg border border-gray-500 px-3 py-2">
+<div class="flex flex-col gap-1 w-full px-3 py-2">
   <div class="flex justify-between">
     <!-- XXXX年XX月 発売予定 -->
     <span>

--- a/app/views/figures/index.html.erb
+++ b/app/views/figures/index.html.erb
@@ -7,7 +7,9 @@
       <div class="flex w-full justify-end pb-3">
         <%= render 'sort', q: @q, url: figures_path %>
       </div>
-      <%= render @figures %>
+      <div class="w-full border rounded-lg divide-y">
+        <%= render @figures %>
+      </div>
     <% else %>
       <span><%= t(".no_data_available") %></span>
     <% end %>


### PR DESCRIPTION
## 概要
一覧画面のフィギュアの枠線のCSSを修正しました

## 背景
フィギュア1個1個が途切れているように見えていたため

## 該当Issue
#82 : 一覧表示のカードの枠線のデザインを修正する

## 変更内容
- 一覧表示のCSSを修正

## 確認方法
※環境構築は完了している & ログインしている前提
1. 一覧表示の見た目が崩れていないことを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/677ed45b-6a12-4bb1-8aa6-f958216d50f8" />

## 補足
- 特記事項はございません