### PR TITLE
refactor: total_priceメソッドを削除

### DIFF
--- a/app/models/figure.rb
+++ b/app/models/figure.rb
@@ -59,14 +59,10 @@ class Figure < ApplicationRecord
     self.manufacturer = Manufacturer.find_or_create_by(name: name)
   end
 
+  # 合計金額を保存するための計算メソッド
   def calculate_total_price
     return if self.price.blank? || self.quantity.blank?
     self.total_price = self.price * self.quantity
-  end
-
-  # 合計金額計算用のメソッド
-  def total_price
-    quantity * price
   end
 
   # 以下3点の　set_仮想カラム名_from_テーブル名　について

--- a/app/views/figures/_figure.html.erb
+++ b/app/views/figures/_figure.html.erb
@@ -1,4 +1,4 @@
-<!-- 一覧画面で表示されるカード -->
+<!-- 一覧画面で表示されるフィギュア -->
 <div class="flex flex-col gap-1 w-full px-3 py-2">
   <div class="flex justify-between">
     <!-- XXXX年XX月 発売予定 -->
@@ -15,12 +15,12 @@
   <div class="text-xl font-bold hover:underline">
     <%= link_to figure.name, figure_path(figure) %>
   </div>
-  <!-- 金額（1個あたり）× 個数 ⇒ 合計（合計はDBに保存していない） -->
+  <!-- 金額（1個あたり）× 個数 ⇒ 合計金額 -->
   <div>
-    <%= "¥#{number_with_delimiter(figure.price)}" %>
+    <%= number_to_currency(figure.price, unit: "¥", format: "%u%n") %>
     <%= "× #{figure.quantity}個 ⇒" %>
     <span class="text-xl font-bold">
-      <%= "¥#{number_with_delimiter(figure.price * figure.quantity)}" %>
+      <%= number_to_currency(figure.total_price, unit: "¥", format: "%u%n") %>
     </span>  
   </div>
 </div>


### PR DESCRIPTION
## 概要
total_priceメソッドを削除しました

## 背景
total_priceカラムを追加したため

## 該当Issue
#119 : 一覧画面の合計金額表示箇所をtotal_priceカラムを使って表示するよう変更する

## 変更内容
- `figure`モデルの`total_price`メソッドを削除
- `price*quantity`で計算して表示している箇所を`total_price`に置換

## 確認方法
※環境構築は完了している & ログインしている前提
1. 一覧画面の表示が崩れていないこと
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/30e1c74c-85e1-47dd-bb35-01e1af9f4a16" />

2. 詳細画面の表示が崩れていないこと
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/5bd5c21b-bced-4e62-87c1-55894ce7d86d" />

## 補足
- 特記事項はございません