### PR TITLE
fix: フッターのレスポンシブ対応

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,13 +3,13 @@
   <nav>
     <div class="px-4 pb-6">
       <ul class="flex justify-center space-x-6 text-gray-600 text-sm">
-        <li><%= link_to "利用規約", '#', class: "hover:underline" %></li>
-        <li><%= link_to "プライバシーポリシー", '#', class: "hover:underline" %></li>
-        <li><%= link_to "お問い合わせ", '#',class: "hover:underline" %></li>
+        <li><%= link_to t("hooter.terms_of_service"), '#', class: "hover:underline" %></li>
+        <li><%= link_to t("hooter.privacy_policy"), '#', class: "hover:underline" %></li>
+        <li><%= link_to t("hooter.contact"), '#',class: "hover:underline" %></li>
       </ul>
     </div>
   </nav>
   <div class=" text-center text-xs text-gray-500">
-    © 2026 figrune
+    <%= t("hooter.copyright") %>
   </div>
 </footer>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -25,6 +25,11 @@ ja:
       update: 更新する
   header:
     create: 登録
+  hooter:
+    terms_of_service: 利用規約
+    privacy_policy: プライバシーポリシー
+    contact: お問い合わせ
+    copyright: © 2026 figrune
   static_pages:
     top:
       hero:


### PR DESCRIPTION
## 概要
フッターのレスポンシブ対応をしました

## 背景
スマホで閲覧時するとフッター内の文字が改行されていたため

## 該当Issue
#126 : フッターのレスポンシブ対応

## 変更内容
- フッター用のビューを修正
- フッター用のビューにコピーライトの追加

## 確認方法
※環境構築は完了している前提
1. フッターのデザイン崩れが起きていないこと
<img width="2142" height="1889" alt="image" src="https://github.com/user-attachments/assets/7d3f32b7-b3aa-4ee6-a418-4e7159ab77d4" />

## 補足
- スマホからも確認し、問題ないことを確認済みです