### PR TITLE
refactor: ヘッダーのUI構造の変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   </head>
 
   <body>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,59 +1,62 @@
 <header class="bg-gray-100 shadow-sm">
   <nav>
-    <div class='w-full max-w-6xl mx-auto px-4'>
-      <div class='flex items-center justify-between h-15'>
+    <div class="w-full max-w-5xl mx-auto px-4">
+      <div class="flex items-center justify-between h-15">
         <!-- ロゴ -->
-        <%= link_to 'Figrune', (user_signed_in? ? figures_path : root_path), class: 'text-xl font-semibold tracking-tight' %>
-
-        <!-- ページ遷移ナビゲーション -->
-        <ul class='flex items-center space-x-5'>
+        <%= link_to 'Figrune', (user_signed_in? ? figures_path : root_path), class: "text-xl font-semibold" %>
+        <ul class="flex items-center space-x-5">
+          <!-- アカウント設定、ログアウト -->
           <% if user_signed_in? %>
             <li>
-              <%= link_to 'アカウント設定', account_setting_path, class: "px-2 py-1 border-b-2 transition
-                #{current_page?(account_setting_path) ?
-                'border-gray-900 text-gray-900 font-medium' :
-                'border-transparent text-gray-600 rounded hover:bg-gray-200 transition'}" %>
+              <%= link_to account_setting_path, class: "p-2 border-b-2
+                  border-transparent text-gray-600 rounded hover:bg-gray-200 transition" do%>
+              <i class="fa-solid fa-user"></i>
+              <span class="hidden md:inline"><%= t("header.account_setting") %></span>
+              <% end %>
             </li>
             <li>
-              <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete },
-                class: "px-2 py-1 border-b-2 transition border-transparent text-gray-600 rounded hover:bg-gray-200 transition" %>
+              <%= link_to destroy_user_session_path, data: { turbo_method: :delete },
+                  class: "p-2 border-b-2 transition border-transparent text-gray-600 rounded hover:bg-gray-200 transition" do %>
+              <i class="fa-solid fa-arrow-right-from-bracket"></i>
+              <span class="hidden md:inline"><%= t("header.logout") %></span>
+              <% end %>
             </li>
+          <!-- 新規登録、ログイン -->
           <% else %>
             <li>
-              <%= link_to '新規登録', new_user_registration_path,
-                class: 'px-2 py-2 text-sm font-medium text-white bg-gray-900 rounded hover:bg-gray-700 transition' %>
+              <%= link_to t("header.sign_up"), new_user_registration_path,
+                  class: "p-2 text-sm font-medium text-white bg-gray-900 rounded hover:bg-gray-700 transition" %>
             </li>            
             <li>
-              <%= link_to 'ログイン', new_user_session_path, class: "px-2 py-1 border-b-2 transition
-                #{current_page?(new_user_session_path) ?
-                'border-gray-900 text-gray-900 font-medium' :
-                'border-transparent text-gray-600 rounded hover:bg-gray-200 transition'}" %>
+              <%= link_to t("header.login"), new_user_session_path, class: "p-2 border-b-2 transition
+                  border-transparent text-gray-600 rounded hover:bg-gray-200" %>
             </li>
           <% end %>
         </ul>
       </div>
-      <div class="flex w-full max-w-3xl mx-auto text-center">
-        <% if user_signed_in? %>
-          <div class="w-full mx-auto">
-            <%= link_to 'ホーム', figures_path, class: "block px-2 py-1 border-b-2 transition
-              #{current_page?(figures_path) ?
-              'border-gray-900 text-gray-900 font-medium' :
-              'border-transparent text-gray-600 rounded hover:bg-gray-200 transition'}" %>
-          </div>
-          <div class="w-full mx-auto">   
-            <%= link_to t("header.create"), new_figure_path, class: "block px-2 py-1 border-b-2 transition
-              #{current_page?(new_figure_path) ?
-              'border-gray-900 text-gray-900 font-medium' :
-              'border-transparent text-gray-600 rounded hover:bg-gray-200 transition'}" %>
-          </div>
-          <div class="w-full mx-auto">   
-            <%= link_to 'グラフ', '#', class: "block px-2 py-1 border-b-2 transition
-              #{current_page?('#') ?
-              'border-gray-900 text-gray-900 font-medium' :
-              'border-transparent text-gray-600 rounded hover:bg-gray-200 transition'}" %>
-          </div>
-        <% end %>
-      </div>
+      <!-- ホーム、登録、グラフ -->
+      <% if user_signed_in? %>
+        <ul class="flex w-full max-w-4xl mx-auto text-center">
+          <li class="w-full">
+            <%= link_to t("header.home"), figures_path, class: "block p-2 border-b-2 transition
+                #{current_page?(figures_path) ?
+                'border-gray-900 text-gray-900 font-medium' :
+                'border-transparent text-gray-600 rounded hover:bg-gray-200'}" %>
+          </li>
+          <li class="w-full">   
+            <%= link_to t("header.create"), new_figure_path, class: "block p-2 border-b-2 transition
+                #{current_page?(new_figure_path) ?
+                'border-gray-900 text-gray-900 font-medium' :
+                'border-transparent text-gray-600 rounded hover:bg-gray-200'}" %>
+          </li>
+          <li class="w-full">   
+            <%= link_to t("header.graph"), '#', class: "block p-2 border-b-2 transition
+                #{current_page?('#') ?
+                'border-gray-900 text-gray-900 font-medium' :
+                'border-transparent text-gray-600 rounded hover:bg-gray-200'}" %>
+          </li>
+        </div>
+      <% end %>
     </div>
   </nav>
 </header>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,62 +1,61 @@
-<div class="bg-white">
-  <!-- Hero / サービスの概要 -->
-  <section class="max-w-4xl mx-auto px-6 py-30 text-center">
-    <h1 class="text-4xl font-bold text-gray-800 leading-tight">
-      <%= t(".hero.title") %>
-    </h1>
-    <p class="mt-6 text-lg text-gray-600">
-      <%= t(".hero.description") %>
-    </p>
-  </section>
-  <!-- Problems / 抱えている問題 -->
-  <section class="bg-gray-50 py-16">
-    <div class="max-w-4xl mx-auto px-6">
-      <h2 class="text-2xl font-bold text-gray-800 text-center"><%= t(".problems.title") %></h2>
-      <div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-8">
-        <div class="rounded-2xl bg-white p-6 shadow-sm">
-          <h3 class="text-lg font-semibold text-gray-800">💸 <%= t(".problems.payment.title") %></h3>
-          <p class="mt-3 text-gray-600 text-sm"><%= t(".problems.payment.description") %></p>
-        </div>
-        <div class="rounded-2xl bg-white p-6 shadow-sm">
-          <h3 class="text-lg font-semibold text-gray-800">📦 <%= t(".problems.forget.title") %></h3>
-          <p class="mt-3 text-gray-600 text-sm"><%= t(".problems.forget.description") %></p>
-        </div>
-        <div class="rounded-2xl bg-white p-6 shadow-sm">
-          <h3 class="text-lg font-semibold text-gray-800">🏠 <%= t(".problems.storage.title") %></h3>
-          <p class="mt-3 text-gray-600 text-sm"><%= t(".problems.storage.description") %></p>
-        </div>
-      </div>
-    </div>
-  </section>
-  <!-- Solution / 解決策 -->
-  <section class="max-w-4xl mx-auto px-6 py-20">
-    <h2 class="text-2xl font-bold text-gray-800 text-center"><%= t(".solution.title") %></h2>
+<!-- Hero / サービスの概要 -->
+<section class="max-w-4xl mx-auto px-6 py-30 text-center">
+  <h1 class="text-4xl font-bold text-gray-800 leading-tight">
+    <%= t(".hero.title") %>
+  </h1>
+  <p class="mt-6 text-lg text-gray-600">
+    <%= t(".hero.description") %>
+  </p>
+</section>
+<!-- Problems / 抱えている問題 -->
+<section class="bg-gray-50 py-16">
+  <div class="max-w-4xl mx-auto px-6">
+    <h2 class="text-2xl font-bold text-gray-800 text-center"><%= t(".problems.title") %></h2>
     <div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-8">
-      <div class="rounded-2xl bg-white p-6 shadow-sm border">
-        <h3 class="text-lg font-semibold text-gray-800">📅 <%= t(".solution.visualize.title") %></h3>
-        <p class="mt-3 text-gray-600 text-sm"><%= t(".solution.visualize.description") %></p>
+      <div class="rounded-2xl bg-white p-6 shadow-sm">
+        <h3 class="text-lg font-semibold text-gray-800">💸 <%= t(".problems.payment.title") %></h3>
+        <p class="mt-3 text-gray-600 text-sm"><%= t(".problems.payment.description") %></p>
       </div>
-      <div class="rounded-2xl bg-white p-6 shadow-sm border">
-        <h3 class="text-lg font-semibold text-gray-800">📊 <%= t(".solution.manage.title") %></h3>
-        <p class="mt-3 text-gray-600 text-sm"><%= t(".solution.manage.description") %></p>
+      <div class="rounded-2xl bg-white p-6 shadow-sm">
+        <h3 class="text-lg font-semibold text-gray-800">📦 <%= t(".problems.forget.title") %></h3>
+        <p class="mt-3 text-gray-600 text-sm"><%= t(".problems.forget.description") %></p>
       </div>
-      <div class="rounded-2xl bg-white p-6 shadow-sm border">
-        <h3 class="text-lg font-semibold text-gray-800">🧠 <%= t(".solution.plan.title") %></h3>
-        <p class="mt-3 text-gray-600 text-sm"><%= t(".solution.plan.description") %></p>
+      <div class="rounded-2xl bg-white p-6 shadow-sm">
+        <h3 class="text-lg font-semibold text-gray-800">🏠 <%= t(".problems.storage.title") %></h3>
+        <p class="mt-3 text-gray-600 text-sm"><%= t(".problems.storage.description") %></p>
+      </div>
+    </div>
+  </div>
+</section>
+<!-- Solution / 解決策 -->
+<section class="max-w-4xl mx-auto px-6 py-20">
+  <h2 class="text-2xl font-bold text-gray-800 text-center"><%= t(".solution.title") %></h2>
+  <div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-8">
+    <div class="rounded-2xl bg-white p-6 shadow-sm border">
+      <h3 class="text-lg font-semibold text-gray-800">📅 <%= t(".solution.visualize.title") %></h3>
+      <p class="mt-3 text-gray-600 text-sm"><%= t(".solution.visualize.description") %></p>
+    </div>
+    <div class="rounded-2xl bg-white p-6 shadow-sm border">
+      <h3 class="text-lg font-semibold text-gray-800">📊 <%= t(".solution.manage.title") %></h3>
+      <p class="mt-3 text-gray-600 text-sm"><%= t(".solution.manage.description") %></p>
+    </div>
+    <div class="rounded-2xl bg-white p-6 shadow-sm border">
+      <h3 class="text-lg font-semibold text-gray-800">🧠 <%= t(".solution.plan.title") %></h3>
+      <p class="mt-3 text-gray-600 text-sm"><%= t(".solution.plan.description") %></p>
+    </div>
+  </div>
+</section>
+<!-- CTA / 行動の促し -->
+<% unless user_signed_in? %>
+  <section class="bg-gray-800 py-16">
+    <div class="max-w-4xl mx-auto px-6 text-center">
+      <h2 class="text-2xl font-bold text-white"><%= t(".cta.title") %></h2>
+      <p class="mt-4 text-gray-300"><%= t(".cta.description") %></p>
+      <div class="mt-8 flex justify-center gap-4">
+        <%= link_to t(".cta.create"), new_user_registration_path, class: 'inline-flex items-center justify-center rounded-lg bg-indigo-600 px-6 py-3 text-white font-medium hover:bg-indigo-700 transition' %>
+        <%= link_to t(".cta.login"), new_user_session_path, class: 'inline-flex items-center justify-center rounded-lg bg-gray-200 px-6 py-3 text-gray-700 font-medium hover:bg-gray-300 transition' %>
       </div>
     </div>
   </section>
-  <!-- CTA / 行動の促し -->
-  <% unless user_signed_in? %>
-    <section class="bg-gray-800 py-16">
-      <div class="max-w-4xl mx-auto px-6 text-center">
-        <h2 class="text-2xl font-bold text-white"><%= t(".cta.title") %></h2>
-        <p class="mt-4 text-gray-300"><%= t(".cta.description") %></p>
-        <div class="mt-8 flex justify-center gap-4">
-          <%= link_to t(".cta.create"), new_user_registration_path, class: 'inline-flex items-center justify-center rounded-lg bg-indigo-600 px-6 py-3 text-white font-medium hover:bg-indigo-700 transition' %>
-          <%= link_to t(".cta.login"), new_user_session_path, class: 'inline-flex items-center justify-center rounded-lg bg-gray-200 px-6 py-3 text-gray-700 font-medium hover:bg-gray-300 transition' %>
-        </div>
-      </div>
-    </section>
-  <% end %>
-</div>
+<% end %>
+

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -24,7 +24,13 @@ ja:
       submit: 保存
       update: 更新する
   header:
+    account_setting: アカウント設定
+    logout: ログアウト
+    sign_up: 新規登録
+    login: ログイン
+    home: ホーム
     create: 登録
+    graph: グラフ
   hooter:
     terms_of_service: 利用規約
     privacy_policy: プライバシーポリシー


### PR DESCRIPTION
## 概要
ヘッダーのUI構造の変更をしました

## 背景
レスポンシブ対応にするため

## 該当Issue
#128 : ヘッダーのUI構造の変更

## 変更内容
- ヘッダー用のビューを変更
- トップページ用のビューから`bg:white`を削除

## 確認方法
※環境構築は完了している前提
1. ログイン前のヘッダーの表示に問題がないこと
<img width="2142" height="1889" alt="image" src="https://github.com/user-attachments/assets/eede4ce4-9df5-44b6-9c23-36404f6cf2d8" />

2. ログイン後のヘッダーの表示に問題がないこと
<img width="2142" height="1889" alt="image" src="https://github.com/user-attachments/assets/d3841c24-ca18-4cc7-ae65-d327eeb4ae31" />

## 補足
- トップページ用のビューから`bg:white`を削除した理由はヘッダーの`shadow-sm`が表示されなくなっていたためです