### PR TITLE
refactor: submitの送信方法を変更

### DIFF
--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -46,7 +46,7 @@ class AccountSettingsController < ApplicationController
   def update_email_notification_timing
     @user = current_user
     if @user.update(email_notification_timing_params)
-      render :show
+      redirect_to account_setting_path
     else
       flash.now[:alert] = t("defaults.flash_message.account_setting.not_updated")
       render :show, status: :unprocessable_entity

--- a/app/javascript/controllers/auto_submit_controller.js
+++ b/app/javascript/controllers/auto_submit_controller.js
@@ -1,8 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  submit() {
-    // フォームを送信
-    this.element.requestSubmit()
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,6 +6,3 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
-
-import AutoSubmitController from "./auto_submit_controller"
-application.register("auto-submit", AutoSubmitController)

--- a/app/views/account_settings/_email_notification_form.html.erb
+++ b/app/views/account_settings/_email_notification_form.html.erb
@@ -1,15 +1,12 @@
-<%= turbo_frame_tag "email_notification" do %>
-  <%= form_with model: @user, 
-                url: update_email_notification_timing_account_setting_path, 
-                method: :patch,
-                data: { controller: "auto-submit" } do |f| %>
-    
-    <div class="form-group">
-      <%= f.select :email_notification_timing,
-                   User.email_notification_timings_i18n.map { |k, v| [v, k] },
-                   {}, 
-                   class: "p-1 border",
-                   data: { action: "change->auto-submit#submit" } %>
-    </div>
-  <% end %>
+<%= form_with model: @user, 
+              url: update_email_notification_timing_account_setting_path, 
+              method: :patch do |f| %>
+  
+  <div class="form-group">
+    <%= f.select :email_notification_timing,
+                  User.email_notification_timings_i18n.map { |k, v| [v, k] },
+                  {}, 
+                  { class: "p-1 border",
+                  onchange: "this.form.submit();" } %>
+  </div>
 <% end %>


### PR DESCRIPTION
## 概要
formの`submit`の送信方法を変更しました

## 背景
`onchange`を使う方がコード量が少なくメンテナンスがしやすいため

## 該当Issue
#130 : メール通知欄の値を非同期で保存するロジックのリファクタ

## 変更内容
- メール通知欄の値を送信するためのパーシャルを変更
- 不要なJSファイルを削除

## 確認方法
※環境構築は完了している & ログインしている前提
1. アカウント設定画面にて、メール通知欄の値を変更したとき、変更した値に保存がされていること

## 補足
- 特記事項はございません