### PR TITLE
style: フラッシュメッセージのデザインの調整

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,22 +20,20 @@
 
   <body>
     <%= render 'shared/header' %>
-
-    <% flash.each do |key, message| %>
-      <% if key == 'notice' %>
-        <div role="alert" class="border-2 bg-green-100 p-4 text-green-500">
-          <div class="flex items-start gap-3">    
-            <div class="block flex-1 leading-tight font-semibold"><%= message %></div>
+    
+    <div class="w-full max-w-4xl mx-auto px-4">
+      <% flash.each do |key, message| %>
+        <% if key == 'notice' %>
+          <div role="status" class="border-2 bg-green-100 p-4 text-green-500">  
+            <div class="font-semibold"><%= message %></div>
           </div>
-        </div>
-      <% else %>
-        <div role="alert" class="border-2 bg-red-100 p-4 text-red-500">
-          <div class="flex items-start gap-3">    
-            <div class="block flex-1 leading-tight font-semibold"><%= message %></div>
+        <% else %>
+          <div role="alert" class="border-2 bg-red-100 p-4 text-red-500">
+            <div class="font-semibold"><%= message %></div>
           </div>
-        </div>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
 
     <%= yield %>
     <%= render 'shared/footer' %>


### PR DESCRIPTION
## 概要
フラッシュメッセージのデザインを調整しました

## 背景
フラッシュメッセージが画面端まで広がっていたため

## 該当Issue
#137 : フラッシュメッセージのデザインの調整

## 変更内容
- `application.html.erb`を修正

## 確認方法
※環境構築は完了している前提
1. フラッシュメッセージが画面端まで広がっていないことを確認
<img width="2142" height="1889" alt="image" src="https://github.com/user-attachments/assets/0c68a8be-fbbe-4ed5-a212-a4292b3835ea" />

## 補足
- 特記事項はございません