### PR TITLE
chore: brakemanの更新

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "~> 8.0", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.20.1)
       msgpack (~> 1.2)
-    brakeman (7.1.2)
+    brakeman (8.0.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -343,7 +343,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
-  brakeman
+  brakeman (~> 8.0)
   capybara
   cssbundling-rails
   debug


### PR DESCRIPTION
## 概要
brakemanのバージョンを更新しました

## 背景
バージョンが古いことでCIが落ちていたため

## 該当Issue
- #174 

## 変更内容
- Gemfileを修正

## 確認方法
※環境構築は完了している前提
1. 既存の機能に問題がないこと

## 補足
- 特記事項はございません