### PR TITLE
fix: 未ログイン状態でアカウント設定画面に遷移できる不具合の修正

### DIFF
--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -1,4 +1,5 @@
 class AccountSettingsController < ApplicationController
+  before_action :authenticate_user!
   def show
     @user = current_user
   end


### PR DESCRIPTION
## 概要
未ログイン状態でアカウント設定画面に遷移できないようにしました

## 背景
未ログイン状態でURLを指定してアカウント設定画面に遷移することができたため

## 該当Issue
- #177 

## 変更内容
- アカウント設定用のコントローラーを修正

## 確認方法
※環境構築は完了している前提
1. ブラウザの検索フィールドに`http://localhost:3000/account_setting`を入力して遷移しようとしてもログイン画面に遷移することを確認
<img width="2160" height="1884" alt="image" src="https://github.com/user-attachments/assets/300b79b9-912f-4fe0-a8d2-b7b1c9012df8" />

## 補足
- 特記事項はございません