### PR TITLE
デプロイのため develop を main にマージ（未ログイン状態でのアカウント設定画面に遷移できる不具合の修正）

### DIFF
--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -1,4 +1,5 @@
 class AccountSettingsController < ApplicationController
+  before_action :authenticate_user!
   def show
     @user = current_user
   end


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- アカウント設定画面に遷移するためのログイン状態の条件

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] 未ログイン状態でアカウント設定画面に遷移できないこと

## 補足
- 特記事項はございません