### PR TITLE
chore: TimeZoneをTokyoに設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,7 @@ module App
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     config.i18n.default_locale = :ja
+
+    config.time_zone = "Tokyo"
   end
 end


### PR DESCRIPTION
## 概要
TimeZoneを設定しました

## 背景
DBなどの表示時刻がUTCだったため

## 該当Issue
- #188 

## 変更内容
- configの`application.rb`にTimeZoneを設定

## 確認方法
※環境構築は完了している前提
1. rails cにてcreated_atなどを確認し、問題ないことを確認

## 補足
- 特記事項はございません