### PR TITLE
feat: 外部サービスでログインした人向けのパスワード設定画面を作成

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :confirmable,
          :omniauthable, omniauth_providers: %i[line]
 
+  attr_accessor :new_password
+  attr_accessor :new_password_confirmation
   has_many :figures, dependent: :destroy
   has_many :authentications, dependent: :destroy
 

--- a/app/views/account_settings/edit_password.html.erb
+++ b/app/views/account_settings/edit_password.html.erb
@@ -1,26 +1,32 @@
-<% content_for(:title, t(".title")) %>
+<% content_for(:title, current_user.has_password_in_database ? t(".title_change") : t(".title_setting")) %>
 <div class="min-h-screen flex items-center justify-center px-4">
   <div class="w-full max-w-md bg-gray-100 rounded-2xl shadow-md p-8">
     <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">
-      <%= t(".title") %>
+      <% if current_user.has_password_in_database %>
+        <%= t(".title_change") %>
+      <% else %>
+        <%= t(".title_setting") %>
+      <% end %>
     </h2>
 
     <%= form_with model: @user, url: update_password_account_setting_path, html: { method: :patch, class: "space-y-5" } do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
 
       <!-- 現在のパスワード -->
-      <div>
-        <%= f.label :current_password, class: "block text-sm font-medium text-gray-700 mb-1" %>
-        <%= f.password_field :current_password, 
-          autofocus: true ,
-          autocomplete: "current-password",
-          class: "w-full rounded-lg border border-gray-300 bg-white px-3 py-2
-                  hover:border-gray-400" %>
-      </div>
+      <% if current_user.has_password_in_database %>
+        <div>
+          <%= f.label :current_password, class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.password_field :current_password, 
+            autofocus: true ,
+            autocomplete: "current-password",
+            class: "w-full rounded-lg border border-gray-300 bg-white px-3 py-2 hover:border-gray-400" %>
+        </div>
+      <% end %>
 
-      <!-- 新しいパスワード -->
+      <!-- 新しいパスワード / パスワード -->
       <div>
-        <%= f.label :password, t(".new_password"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.label :password, current_user.has_password_in_database ? t(".new_password") : t(".password"),
+            class: "block text-sm font-medium text-gray-700 mb-1" %>
         <% if User.password_length.min %>
           <p class="text-xs text-gray-500 mb-1">
             <%= t(".password_hint", min: User.password_length.min) %>
@@ -28,23 +34,22 @@
         <% end %>
         <%= f.password_field :password,
           autocomplete: "new-password",
-          class: "w-full rounded-lg border border-gray-300 bg-white px-3 py-2
-                  hover:border-gray-400" %>
+          class: "w-full rounded-lg border border-gray-300 bg-white px-3 py-2 hover:border-gray-400" %>
       </div>
 
-      <!-- 新しいパスワード（確認） -->
+      <!-- 新しいパスワード（確認）/ パスワード（確認） -->
       <div>
-        <%= f.label :password_confirmation, t(".new_password_confirmation"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.label :password_confirmation, current_user.has_password_in_database ? t(".new_password") : t(".password_confirmation"),
+            class: "block text-sm font-medium text-gray-700 mb-1" %>
         <%= f.password_field :password_confirmation,
-          autocomplete: "new-password",
-          class: "w-full rounded-lg border border-gray-300 bg-white px-3 py-2
-                  hover:border-gray-400" %>
+            autocomplete: "new-password",
+            class: "w-full rounded-lg border border-gray-300 bg-white px-3 py-2 hover:border-gray-400" %>
       </div>
 
-      <!-- 「変更する」ボタン -->
+      <!-- 「変更する」ボタン/ 「登録する」ボタン -->
       <div>
-        <%= f.submit t(".submit"),
-          class: "w-full py-2.5 rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
+        <%= f.submit current_user.has_password_in_database ? t(".change") : t(".setting"),
+            class: "w-full py-2.5 rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
       </div>
     <% end %>
   </div>

--- a/app/views/account_settings/show.html.erb
+++ b/app/views/account_settings/show.html.erb
@@ -9,13 +9,15 @@
   <dl class="my-3 divide-y divide-gray-400">
     <!-- メールアドレス変更 -->
     <div class="grid grid-cols-2 py-3 sm:grid-cols-3">
-      <dt class="font-bold"><%= t(".change_email") %></dt>
+      <dt class="font-bold"><%= t(".email") %></dt>
       <dd class="text-gray-700 sm:col-span-2"><%= link_to t('.change'), edit_email_account_setting_path, class: "text-blue-500 hover:underline font-medium"%></dd>
     </div>
     <!-- パスワード変更 -->
     <div class="grid grid-cols-2 py-3 sm:grid-cols-3">
-      <dt class="font-bold"><%= t(".change_password") %></dt>
-      <dd class="text-gray-700 sm:col-span-2"><%= link_to t('.change'), edit_password_account_setting_path, class: "text-blue-500 hover:underline font-medium"%></dd>
+      <dt class="font-bold"><%= t(".password") %></dt>
+      <dd class="text-gray-700 sm:col-span-2">
+        <%= link_to current_user.has_password ? t('.change') : t('.setting'), edit_password_account_setting_path, class: "text-blue-500 hover:underline font-medium"%>
+      </dd>
     </div>
   </dl>
   <!-- 通知設定 -->
@@ -26,7 +28,6 @@
     <!-- メール通知 -->
     <div class="grid grid-cols-2 py-3 items-center sm:grid-cols-3">
       <dt class="font-bold"><%= t(".email_notification") %></dt>
-      <!-- ↓はセレクトボックスの予定 -->
       <dd class="text-gray-700 sm:col-span-2">
         <%= render 'account_settings/email_notification_form' %>
       </dd>

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -5,6 +5,8 @@ ja:
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "パスワード（確認）"
+        new_password: 新しいパスワード
+        new_password_confirmation: 新しいパスワード（確認）
       figure:
         name: 商品名
         release_month: 発売月

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -22,12 +22,18 @@ ja:
       deleted: 削除しました
       account_setting:
         not_updated: 変更できませんでした
+        not_setting: 設定できませんでした
         updated: 確認メールを送信しました
         password_updated: パスワードを変更しました
+        password_setting: パスワードを設定しました
       omniauth_callback:
         email_taken: メールアドレスは既に存在します
         auth_save_failure: 認証情報の保存に失敗しました
         invalid_credential: 認証に失敗しました
+    error_message:
+      blank: を入力してください
+      short: "は%{min}文字以上で入力してください"
+      confirmation: と新しいパスワードの入力が一致しません
   helpers:
     submit:
       create: 登録する
@@ -126,9 +132,10 @@ ja:
     show:
       title: アカウント設定
       personal_information_setting: 個人情報設定
-      change_email: メールアドレス変更
-      change_password: パスワード変更
+      email: メールアドレス
+      password: パスワード
       change: 変更
+      setting: 設定
       notification_setting: 通知設定
       email_notification: メール通知
       back: 戻る
@@ -139,8 +146,13 @@ ja:
       description: 入力したメールアドレス宛に確認メールを送信します。メール内のURLをクリックすると、メールアドレスの変更が完了します。
       submit: 変更する
     edit_password:
-      title: パスワード変更
+      title_change: パスワード変更
+      title_setting: パスワード設定
       new_password: 新しいパスワード
+      password: パスワード
       new_password_confirmation: 新しいパスワード（確認）
+      password_confirmation: パスワード（確認）
       password_hint: "※%{min}文字以上"
-      submit: 変更する
+      change: 変更する
+      setting: 設定する
+


### PR DESCRIPTION
## 概要
外部サービスでログインした人向けのパスワード設定画面を作成しました

## 背景
パスワードでもログインができるようにするため

## 該当Issue
- #152 

## 変更内容
- パスワード変更用のビューを改修
- パスワード変更用の`update_password`アクションを改修
- アカウント設定画面用のビューを改修

## 確認方法
※環境構築は完了している前提
1. メールアドレス、パスワードでログイン後、ヘッダーの`アカウント設定`をクリックする
2. パスワード欄が`変更`になっていることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/68e73bff-2cb5-466c-b407-25a19e968bb0" />

3. `変更`をクリック後、パスワード変更画面が表示されることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/b1676197-7426-4014-82ba-1250b07d6bf8" />

4. 外部サービスでログインし、ヘッダーの`アカウント設定`をクリックする
5. パスワード欄が`設定`になっていることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/59884ec2-98de-4884-a001-362c8bfef9f9" />

6. `設定`をクリック後、パスワード設定画面が表示されることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/5f4d1b11-8922-47b2-8f92-f55ad399c0f5" />

7. パスワードを入力し、設定できること＆パスワード欄が`変更`に切り替わっていることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/cc5e6232-12f8-47cb-878a-7ffb192519cc" />

## 補足
- 特記事項はございません