### PR TITLE
デプロイのため develop を main にマージ（外部サービスでログインした人向けのメールアドレス設定機能と画面を追加）

### DIFF
--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -18,7 +18,7 @@ class AccountSettingsController < ApplicationController
     if @user.update_without_password(email_params)
       redirect_to account_setting_path, notice: t("defaults.flash_message.account_setting.updated")
     else
-      flash.now[:alert] = t("defaults.flash_message.account_setting.not_updated")
+      flash.now[:alert] = t("defaults.flash_message.account_setting.failured", action_word: @user.email_action_word)
       render :edit_email, status: :unprocessable_entity
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,4 +29,22 @@ class User < ApplicationRecord
       nil
     end
   end
+
+  def email_action_word
+    has_email_in_database ? I18n.t("defaults.account_setting.update") : I18n.t("defaults.account_setting.setup")
+  end
+
+  # メール認証をクリックしたときの処理
+  # has_emailで万が一、更新に失敗したときはロールバックする。
+  def confirm(arg = {})
+    ActiveRecord::Base.transaction do
+      result = super  # Devise の元の confirm メソッドを呼ぶ
+      update!(has_email: true) if result
+      result
+    end
+    rescue => e
+      Rails.logger.error(I18n.t("defaults.confirm_error_log", error: e.message))
+      errors.add(:base, I18n.t("defaults.confirm_error"))
+      false
+  end
 end

--- a/app/views/account_settings/edit_email.html.erb
+++ b/app/views/account_settings/edit_email.html.erb
@@ -1,40 +1,41 @@
-
-<% content_for(:title, t(".title")) %>
+<% content_for(:title, t(".title", action_word: @user.email_action_word)) %>
 <div class="min-h-screen flex items-center justify-center px-4">
   <div class="w-full max-w-md bg-gray-100 rounded-2xl shadow-md p-8">
     <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">
-      <%= t(".title") %>
+      <%= t(".title", action_word: @user.email_action_word) %>
     </h2>
 
-    <%= form_with model: @user, url: update_email_account_setting_path, html: { method: :patch, class: "space-y-5" } do |f| %>
+    <%= form_with model: @user, url: update_email_account_setting_path, html: { method: :patch, class: "space-y-6" } do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
 
       <!-- 説明 -->
       <div class="text-sm">
-        <%= t(".description") %>
+        <%= t(".description", action_word: @user.email_action_word) %>
       </div>
+      
+      <% if @user.has_email_in_database %>
+        <!-- 現在のメールアドレス -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-1">
+            <%= t(".current_email") %>
+          </label>
+          <span class="p-2"><%= @user.email_in_database%></span>
+        </div>
+      <% end %>
 
-      <!-- 現在のメールアドレス -->
+      <!-- 新しいメールアドレス / メールアドレス -->
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1">
-          <%= t(".current_email") %>
-        </label>
-        <span class="px-3 py-2"><%= @user.email_in_database%></span>
-      </div>
-
-      <!-- 新しいメールアドレス -->
-      <div>
-        <%= f.label :email, t(".new_email"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.label :email, @user.has_email_in_database ? t(".new_email") : t(".email"),
+            class: "block text-sm font-medium text-gray-700 mb-1" %>
         <%= f.email_field :email,
-          autofocus: true ,
-          autocomplete: "email",
-          class: "w-full rounded-lg border border-gray-300 bg-white px-3 py-2
-                  hover:border-gray-400" %>
+            autofocus: true,
+            autocomplete: "email",
+            class: "w-full rounded-lg border border-gray-300 bg-white p-2 hover:border-gray-400" %>
       </div>
 
-      <!-- ボタン -->
+      <!-- 「変更する」/「設定する」ボタン -->
       <div>
-        <%= f.submit t(".submit"),
+        <%= f.submit t(".submit", action_word: @user.email_action_word),
           class: "w-full py-2.5 rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
       </div>
     <% end %>

--- a/app/views/account_settings/show.html.erb
+++ b/app/views/account_settings/show.html.erb
@@ -7,12 +7,12 @@
     <%= t(".personal_information_setting") %>
   </h3>
   <dl class="my-3 divide-y divide-gray-400">
-    <!-- メールアドレス変更 -->
+    <!-- メールアドレス変更 / 設定 -->
     <div class="grid grid-cols-2 py-3 sm:grid-cols-3">
       <dt class="font-bold"><%= t(".email") %></dt>
-      <dd class="text-gray-700 sm:col-span-2"><%= link_to t('.change'), edit_email_account_setting_path, class: "text-blue-500 hover:underline font-medium"%></dd>
+      <dd class="text-gray-700 sm:col-span-2"><%= link_to @user.email_action_word, edit_email_account_setting_path, class: "text-blue-500 hover:underline font-medium"%></dd>
     </div>
-    <!-- パスワード変更 -->
+    <!-- パスワード変更 / 設定 -->
     <div class="grid grid-cols-2 py-3 sm:grid-cols-3">
       <dt class="font-bold"><%= t(".password") %></dt>
       <dd class="text-gray-700 sm:col-span-2">

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -14,6 +14,8 @@ ja:
     optional_details: 詳細情報を入力（任意）
     please_select: 選択してください
     delete_confirm: 本当に削除してよろしいですか？
+    confirm_error_log: "メール認証エラー：%{error}"
+    confirm_error: メール認証中にエラーが発生しました。再度確認メールを送信をしてください。
     flash_message:
       created: 登録しました
       not_created: 登録できませんでした
@@ -21,7 +23,8 @@ ja:
       not_updated: 更新できませんでした
       deleted: 削除しました
       account_setting:
-        not_updated: 変更できませんでした
+        failured: "%{action_word}できませんでした"
+        not_updated: 更新できませんでした
         not_setting: 設定できませんでした
         updated: 確認メールを送信しました
         password_updated: パスワードを変更しました
@@ -30,6 +33,9 @@ ja:
         email_taken: メールアドレスは既に存在します
         auth_save_failure: 認証情報の保存に失敗しました
         invalid_credential: 認証に失敗しました
+    account_setting:
+      update: 変更
+      setup: 設定
     error_message:
       blank: を入力してください
       short: "は%{min}文字以上で入力してください"
@@ -37,8 +43,8 @@ ja:
   helpers:
     submit:
       create: 登録する
-      submit: 保存
       update: 更新する
+
   header:
     account_setting: アカウント設定
     logout: ログアウト
@@ -140,11 +146,12 @@ ja:
       email_notification: メール通知
       back: 戻る
     edit_email:
-      title: メールアドレス変更
+      title: "メールアドレス%{action_word}"
       current_email: 現在のメールアドレス
       new_email: 新しいメールアドレス
-      description: 入力したメールアドレス宛に確認メールを送信します。メール内のURLをクリックすると、メールアドレスの変更が完了します。
-      submit: 変更する
+      email: メールアドレス
+      description: "入力したメールアドレス宛に確認メールを送信します。メール内のURLをクリックすると、メールアドレスの%{action_word}が完了します。"
+      submit: "%{action_word}する"
     edit_password:
       title_change: パスワード変更
       title_setting: パスワード設定


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- メールアドレス設定画面
- メールアドレス設定機能

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] 外部サービスでログインした人はメールアドレス設定ができること

## 補足
- 特記事項はございません