### PR TITLE
デプロイのため develop を main にマージ（アカウント設定画面にLINE通知の設定欄を追加）

### DIFF
--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -65,12 +65,24 @@ class AccountSettingsController < ApplicationController
     end
   end
 
+  # メール通知のセレクトボックスが変化したら実行
   def update_email_notification_timing
     @user = current_user
     if @user.update(email_notification_timing_params)
       redirect_to account_setting_path
     else
-      flash.now[:alert] = t("defaults.flash_message.account_setting.not_updated")
+      flash.now[:alert] = t("defaults.flash_message.account_setting.update_failured")
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  # LINE通知のセレクトボックスが変化したら実行
+  def update_line_notification_timing
+    @user = current_user
+    if @user.update(line_notification_timing_params)
+      redirect_to account_setting_path
+    else
+      flash.now[:alert] = t("defaults.flash_message.account_setting.update_failured")
       render :show, status: :unprocessable_entity
     end
   end
@@ -91,5 +103,9 @@ class AccountSettingsController < ApplicationController
 
   def email_notification_timing_params
     params.require(:user).permit(:email_notification_timing)
+  end
+
+  def line_notification_timing_params
+    params.require(:user).permit(:line_notification_timing)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,11 @@ class User < ApplicationRecord
   has_many :figures, dependent: :destroy
   has_many :authentications, dependent: :destroy
 
-  # 通知のタイミング：0:通知なし、1:1週間前、2:2週間前、3:3週間前、4:1か月前、 5:2か月前
-  enum email_notification_timing: { disabled: 0, one_week_before: 1, two_week_before: 2, three_week_before: 3, one_month_before: 4, two_month_before: 5 }
+  # メール通知のタイミング：0:通知なし、1:1週間前、2:2週間前、3:3週間前、4:1か月前、 5:2か月前
+  enum :email_notification_timing, { disabled: 0, one_week_before: 1, two_week_before: 2, three_week_before: 3, one_month_before: 4, two_month_before: 5 }, prefix: true
+
+  # LINE通知のタイミング：0:通知なし、1:1週間前、2:2週間前、3:3週間前、4:1か月前、 5:2か月前
+  enum :line_notification_timing, { disabled: 0, one_week_before: 1, two_week_before: 2, three_week_before: 3, one_month_before: 4, two_month_before: 5 }, prefix: true
 
   def notification_date_for(month_date)
     case email_notification_timing

--- a/app/views/account_settings/_line_notification_form.html.erb
+++ b/app/views/account_settings/_line_notification_form.html.erb
@@ -1,0 +1,12 @@
+<%= form_with model: @user, 
+              url: update_line_notification_timing_account_setting_path, 
+              method: :patch do |f| %>
+  
+  <div class="form-group">
+    <%= f.select :line_notification_timing,
+                  User.line_notification_timings_i18n.map { |k, v| [v, k] },
+                  {}, 
+                  { class: "p-1 border",
+                  onchange: "this.form.submit();" } %>
+  </div>
+<% end %>

--- a/app/views/account_settings/show.html.erb
+++ b/app/views/account_settings/show.html.erb
@@ -32,6 +32,13 @@
         <%= render 'account_settings/email_notification_form' %>
       </dd>
     </div>
+    <!-- LINE通知 -->
+    <div class="grid grid-cols-2 py-3 items-center sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".line_notification") %></dt>
+      <dd class="text-gray-700 sm:col-span-2">
+        <%= render 'account_settings/line_notification_form' %>
+      </dd>
+    </div>
   </dl>
   <div class="max-w-sm mx-auto flex flex-col">
     <!-- 戻るボタン -->

--- a/config/locales/activerecord.ja.yml
+++ b/config/locales/activerecord.ja.yml
@@ -29,6 +29,13 @@ ja:
         three_week_before: 3週間前
         one_month_before: 1ヶ月前
         two_month_before: 2ヶ月前
+      line_notification_timing:
+        disabled: 通知なし
+        one_week_before: 1週間前
+        two_week_before: 2週間前
+        three_week_before: 3週間前
+        one_month_before: 1ヶ月前
+        two_month_before: 2ヶ月前
     figure:
       payment_status:
         unpaid: 未払い

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -24,6 +24,7 @@ ja:
       deleted: 削除しました
       account_setting:
         failured: "%{action_word}できませんでした"
+        update_failured: 予期せぬエラーで変更できませんでした
         not_updated: 更新できませんでした
         not_setting: 設定できませんでした
         updated: 確認メールを送信しました
@@ -44,7 +45,6 @@ ja:
     submit:
       create: 登録する
       update: 更新する
-
   header:
     account_setting: アカウント設定
     logout: ログアウト
@@ -144,6 +144,7 @@ ja:
       setting: 設定
       notification_setting: 通知設定
       email_notification: メール通知
+      line_notification: LINE通知
       back: 戻る
     edit_email:
       title: "メールアドレス%{action_word}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root "static_pages#top"
   get "/home", to: "home#index"
   resources :figures, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     get :autocomplete, on: :collection
@@ -12,13 +13,13 @@ Rails.application.routes.draw do
     get   :edit_password
     patch :update_password
     patch :update_email_notification_timing
+    patch :update_line_notification_timing
   end
   devise_for :users, controllers: {
     registrations: "users/registrations",
     confirmations: "users/confirmations",
     omniauth_callbacks: "omniauth_callbacks"
   }
-  root "static_pages#top"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20260214015034_add_line_notification_timing_to_users.rb
+++ b/db/migrate/20260214015034_add_line_notification_timing_to_users.rb
@@ -1,0 +1,5 @@
+class AddLineNotificationTimingToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :line_notification_timing, :integer, default: 4, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_10_073619) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_14_015034) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,6 +72,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_10_073619) do
     t.integer "email_notification_timing", default: 4, null: false
     t.boolean "has_password", default: true, null: false
     t.boolean "has_email", default: true, null: false
+    t.integer "line_notification_timing", default: 4, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- LINE通知のタイミング設定機能

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] アカウント設定画面にLINE通知のタイミング設定欄が表示されること
- [x] LINE通知のタイミング設定欄はセレクトボックスの値を選ぶことで設定できること

## 補足
- 特記事項はございません