### PR TITLE
fix: `update_payment_status.yml`のワークフロー名（name）を修正しました

### DIFF
--- a/.github/workflows/update_payment_status.yml
+++ b/.github/workflows/update_payment_status.yml
@@ -1,4 +1,4 @@
-name: figure_payment_notification
+name: update_payment_status
 
 on:
   schedule:


### PR DESCRIPTION
## 概要
`update_payment_status.yml`のワークフロー名（name）を修正しました

## 背景
ワークフローのnameが別タスクの名称になっていたため

## 該当Issue
- #200 

## 変更内容
- `update_payment_status.yml`の`name`を修正

## 確認方法
- 確認事項はございません

## 補足
- 特記事項はございません