### PR TITLE
fix: ホーム画面で期間を指定後、月ボタンをクリックすると指定した期間が今月から12か月に勝手に戻る不具合の修正

### DIFF
--- a/app/views/home/_month_selector.html.erb
+++ b/app/views/home/_month_selector.html.erb
@@ -7,10 +7,10 @@
     <!-- 月のボタン -->
     <div class="flex flex-wrap gap-2">
       <% months.each do |month| %>
-        <% selected = params[:selected_month] == month.strftime("%Y-%m") %>
+        <% selected = selected_month == month %>
         <%= link_to month.strftime("%m月"),
             home_path(from: params[:from], to: params[:to], selected_month: month.strftime("%Y-%m")),
-            class: "px-2 py-1 rounded border text-sm text-gray-500 hover:bg-gray-200" %>
+            class: "px-2 py-1 rounded border text-sm #{selected ? 'bg-black text-white' : 'text-gray-500 hover:bg-gray-200'}" %>
       <% end %>
     </div>
   </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,7 +4,7 @@
       <!-- 範囲指定UI -->
       <%= render 'date_range', url: home_path %>
       <!-- 範囲指定内の月選択UI -->
-      <%= render "month_selector", months: @months %>
+      <%= render "month_selector", months: @months, selected_month: @selected_month %>
       <!-- 棒グラフ(chart.js) -->
       <div class="w-full h-[260px] md:h-[420px]">
         <canvas


### PR DESCRIPTION
## 概要
ホーム画面で期間を指定後、月ボタンをクリックすると指定した期間が今月から12か月に勝手に戻る不具合の修正をしました

## 背景
期間を指定したにもかかわらず、月ボタンをクリックするたびに期間がリセットされるのはUXがわるいため

## 該当Issue
- #204 

## 変更内容
- ホーム画面の`index.html.erb`を修正
- 月ボタン用のパーシャルを改修

## 確認方法
※環境構築は完了している & ログインしている前提
1. ホーム画面にて期間を指定して、月ボタンをクリックすしたとき、期間がリセットされないことを確認
2. クリックした月ボタンの背景が黒になることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/8d7c13b1-7d27-4560-ab0e-e75a095f8024" />


## 補足
- 特記事項はございません