### PR TITLE
feat: プライバシーポリシーの作成

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,5 @@
 class StaticPagesController < ApplicationController
-  def top
-  end
+  def top; end
+
+  def privacy_policy; end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -4,7 +4,7 @@
     <div class="px-4 pb-6">
       <ul class="flex justify-center space-x-6 text-gray-600 text-sm">
         <li><%= link_to t("hooter.terms_of_service"), '#', class: "hover:underline" %></li>
-        <li><%= link_to t("hooter.privacy_policy"), '#', class: "hover:underline" %></li>
+        <li><%= link_to t("hooter.privacy_policy"), privacy_policy_path, class: "hover:underline" %></li>
         <li><%= link_to t("hooter.contact"), '#',class: "hover:underline" %></li>
       </ul>
     </div>

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,0 +1,112 @@
+<%# app/views/pages/privacy_policy.html.erb %>
+
+<div class="min-h-screen py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-4xl mx-auto rounded-lg overflow-hidden text-gray-700 leading-relaxed">
+    
+    <div class="px-6 py-8 border-b border-gray-700">
+      <h1 class="text-3xl font-bold text-gray-900 mb-2">プライバシーポリシー</h1>
+      <p class="text-sm text-gray-500">最終更新日：2026年2月16日</p>
+    </div>
+
+    <div class="px-6 py-8 space-y-10">
+      <section>
+        <p>
+          Figrune（以下「当社」といいます。）は、本サービスにおけるユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下「本ポリシー」といいます。）を定めます。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-xl font-bold text-gray-900 mb-4 flex items-center">
+          <span class="w-1.5 h-6 bg-blue-600 rounded-full mr-3"></span>
+          第1条（個人情報の取得方法）
+        </h2>
+        <p class="mb-3">当社は、本サービスにおいて以下の情報を取得することがあります。</p>
+        <ul class="list-disc ml-8 space-y-3">
+          <li>
+            <strong>直接提供いただく情報：</strong><br>
+            アカウント作成時に登録いただくメールアドレスおよびパスワード。なお、パスワードはハッシュ化され、当社側でも内容を確認できない状態で安全に保存されます。
+          </li>
+          <li>
+            <strong>LINE連携に関する情報：</strong><br>
+            ユーザーがLINEログインを利用する際、LINE株式会社から提供されるユーザー識別子、プロフィール情報（表示名、画像）、およびメールアドレス（ユーザーの同意がある場合）を取得します。
+          </li>
+          <li>
+            <strong>クッキー（Cookie）およびアクセス解析ツール：</strong><br>
+            本サービスでは、Googleによるアクセス解析ツール「Googleアナリティクス」を使用し、データの収集のためにCookieを使用しています。このデータは匿名で収集されており、個人を特定するものではありません。
+          </li>
+          <li>
+            <strong>お問い合わせ情報：</strong><br>
+            お問い合わせフォーム等に入力されたメールアドレス、お問い合わせ内容。
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="text-xl font-bold text-gray-900 mb-4 flex items-center">
+          <span class="w-1.5 h-6 bg-blue-600 rounded-full mr-3"></span>
+          第2条（利用目的）
+        </h2>
+        <p class="mb-3">取得した情報は、以下の目的で利用します。</p>
+        <ul class="list-disc ml-8 space-y-2">
+          <li>本サービスのログイン機能（メールアドレス・LINE）の提供および本人確認のため</li>
+          <li>本サービスの利用状況の分析およびサービス改善のため</li>
+          <li>ユーザーからのお問い合わせへの回答のため</li>
+          <li>メンテナンスや重要なお知らせの通知のため</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="text-xl font-bold text-gray-900 mb-4 flex items-center">
+          <span class="w-1.5 h-6 bg-blue-600 rounded-full mr-3"></span>
+          第3条（個人情報の管理および第三者提供）
+        </h2>
+        <p class="mb-3">当社は、情報の漏えいや紛失を防止するため、適切なセキュリティ対策を講じます。また、以下の場合を除き、個人情報を第三者に提供しません。</p>
+        <ul class="list-disc ml-8 space-y-2 text-sm">
+          <li>ユーザーの同意がある場合</li>
+          <li>法令に基づく場合</li>
+          <li><strong>外部委託：</strong> 利用目的の達成に必要な範囲内で、サーバー運営会社等に業務を委託する場合。</li>
+          <li><strong>Googleへのデータ提供：</strong> Googleアナリティクスの規約に基づくデータ送信。詳細は<a href="https://policies.google.com/technologies/partner-sites?hl=ja" class="text-blue-600 hover:underline" target="_blank" rel="noopener noreferrer">Googleのポリシーと規約</a>をご確認ください。</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="text-xl font-bold text-gray-900 mb-4 flex items-center">
+          <span class="w-1.5 h-6 bg-blue-600 rounded-full mr-3"></span>
+          第4条（プライバシーポリシーの変更）
+        </h2>
+        <p class="mb-3">当社は、本プライバシーポリシーの内容を変更することがあります。</p>
+        <ul class="list-disc ml-8 space-y-2 text-sm">
+          <li>本ポリシーの内容は，法令その他本ポリシーに別段の定めのある事項を除いて，ユーザーに通知することなく，変更することができるものとします。</li>
+          <li>当社が別途定める場合を除いて，変更後のプライバシーポリシーは，本ウェブサイトに掲載したときから効力を生じるものとします。</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="text-xl font-bold text-gray-900 mb-4 flex items-center">
+          <span class="w-1.5 h-6 bg-blue-600 rounded-full mr-3"></span>
+          第5条（情報の修正・削除および退会）
+        </h2>
+        <p class="mb-3">
+          ユーザーは、GoogleアナリティクスのCookieを無効にすることで、データの収集を拒否することが可能です。また、当社が保持する個人情報の開示・訂正・削除を希望される場合は、お問い合わせ窓口までご連絡ください。
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-xl font-bold text-gray-900 mb-4 flex items-center">
+          <span class="w-1.5 h-6 bg-blue-600 rounded-full mr-3"></span>
+          第6条（お問い合わせ窓口）
+        </h2>
+        <p class="mb-3">
+          お問い合わせは、以下の窓口までお願いいたします。
+        </p>
+        <p>  
+          Email：figrune.app@gmail.com
+        </p>
+      </section>
+
+      <div class="text-right pt-4">
+        <p class="font-bold text-gray-900 text-lg">以上</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root "static_pages#top"
   get "/home", to: "home#index"
+  get "/privacy_policy", to: "static_pages#privacy_policy"
   resources :figures, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
     get :autocomplete, on: :collection
     get :autocomplete_work, on: :collection


### PR DESCRIPTION
## 概要
プライバシーポリシーの作成をしました

## 背景
ユーザーの信頼とトラブルを未然に防ぐため

## 該当Issue
- #43 

## 変更内容
- プライバシーポリシー用のビューを作成
- プライバシーポリシーを表示するためのアクションをコントローラーに追加
- フッターに導線の追加

## 確認方法
※環境構築は完了している前提
1. ログイン状態にかかわらず、フッターの`プライバシーポリシー`をクリックでプライバシーポリシーが表示されることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/a8eded5a-9004-4946-a7ab-0bb8a2250d2b" />


## 補足
- 特記事項はございません