### PR TITLE
feat: サイズの登録バリデーションを追加

### DIFF
--- a/app/models/figure.rb
+++ b/app/models/figure.rb
@@ -6,6 +6,7 @@ class Figure < ApplicationRecord
   validates :payment_status, presence: true
   validates :size_mm, numericality: { greater_than_or_equal_to: 1, allow_blank: true }
   validates :note, length: { maximum: 65_535 }
+  validate :size_type_and_mm_consistency
 
   belongs_to :user
   belongs_to :manufacturer, optional: true
@@ -91,5 +92,17 @@ class Figure < ApplicationRecord
     shop_name.present? ||
     manufacturer_name.present? ||
     note.present?
+  end
+
+  private
+
+  def size_type_and_mm_consistency
+    if size_type.present? ^ size_mm.present?
+      if size_type.present?
+        errors.add(:size_mm, I18n.t("errors.messages.blank"))
+      elsif size_mm.present?
+        errors.add(:size_type, I18n.t("errors.messages.blank"))
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
サイズの登録バリデーションを追加しました

## 背景
片方（サイズ種別orサイズ（mm））だけ入力で登録が出来ていたため

## 該当Issue
- #172 

## 変更内容
- `Figure`モデルにカスタムバリデーションを追加

## 確認方法
※環境構築は完了している & ログインしている前提
1. ヘッダーの`登録`をクリックし、サイズの片方（サイズ種別orサイズ（mm））だけ入力した場合、エラーメッセージが表示されることを確認
- サイズ種別が空白、サイズ（mm）が入力済み
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/b68ae612-5f39-44b0-aef7-94152a4ee274" />

- サイズ種別が入力済み、サイズ（mm）が空白
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/ddad47f3-0586-4dfa-a91f-2d4bee658cf6" />

## 補足
- 特記事項はございません