### PR TITLE
feat: 確認メール再送信画面を改修

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -26,6 +26,14 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
       new_session_path(resource_name)
     end
   end
+
+  def after_resending_confirmation_instructions_path_for(resource_name)
+    if signed_in?(resource_name)
+      account_setting_path
+    else
+      new_session_path(resource_name)
+    end
+  end
   # def after_resending_confirmation_instructions_path_for(resource_name)
   #   super(resource_name)
   # end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,16 +1,32 @@
-<h2>Resend confirmation instructions</h2>
+<% content_for(:title, t(".title", action_word: @user.email_action_word)) %>
+<div class="min-h-screen flex items-center justify-center px-4">
+  <div class="w-full max-w-md bg-gray-100 rounded-2xl shadow-md p-8">
+    <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">
+      <%= t(".title", action_word: @user.email_action_word) %>
+    </h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: "space-y-6" }) do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+      <!-- 説明 -->
+      <div class="text-sm">
+        <%= t(".description_html") %>
+      </div>
+
+      <!-- メールアドレス -->
+      <div>
+        <%= f.label :email, class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= f.email_field :email,
+            autofocus: true,
+            autocomplete: "email",
+            class: "w-full rounded-lg border border-gray-300 bg-white p-2 hover:border-gray-400" %>
+      </div>
+
+      <!-- 「変更する」/「設定する」ボタン -->
+      <div>
+        <%= f.submit t(".submit", action_word: @user.email_action_word),
+          class: "w-full py-2.5 rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
+      </div>
+    <% end %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/config/locales/devise.view.ja.yml
+++ b/config/locales/devise.view.ja.yml
@@ -3,7 +3,14 @@
 ja:
   devise:
     mailer:
-      subject: メールアドレス変更手続きのお知らせ
+      confirmation_instructions:
+        subject: メールアドレス変更手続きのお知らせ
+    confirmations:
+      send_instructions: 確認メールを送信しました
+      new:
+        title: 確認メールの再送信
+        description_html: 確認メールの有効期限が切れているか、無効になっています。<br>もう一度メールアドレスを入力し、メールを送信してください。<br>もしくは、メールアドレス変更画面から再度メールを送信してください。
+        submit: 送信する
     registrations:
       new:
         title: アカウント登録


### PR DESCRIPTION
## 概要
確認メール再送信画面を改修しました

## 背景
確認メールの有効期限が切れた際に遷移する先のページがdeviseのデフォルトデザインだとデザインの統一感がないため

## 該当Issue
- #212 

## 変更内容
- 再送信用のビューを改修
- 確認メール用のコントローラーに再送信後の遷移先を指定するメソッドを作成

## 確認方法
※環境構築は完了している前提
1. 確認メールの再送信画面が改修されていることを確認
<img width="2142" height="1886" alt="image" src="https://github.com/user-attachments/assets/a3d292c8-c4c5-4286-94ff-6949611e6eb1" />

## 補足
- 特記事項はございません