### PR TITLE
fix: SNSアカウントでの登録処理にトランザクション処理を実装

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -25,19 +25,28 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # 新規登録用
   def register_external_user(omniauth, authentication)
     email = omniauth["info"]["email"] || "#{omniauth["uid"]}-#{omniauth["provider"]}@example.com"
-    user = User.new(email: email, password: Devise.friendly_token[0, 20], has_email: @omniauth["info"]["email"].present?, has_password: false)
+    user = User.new(email: email, password: Devise.friendly_token[0, 20], has_email: omniauth["info"]["email"].present?, has_password: false)
 
     # 認証メールのスキップ
     user.skip_confirmation!
-    unless user.save
-      return redirect_to new_user_session_path, alert: t("defaults.flash_message.omniauth_callback.email_taken")
-    end
-    authentication.user = user
-    unless authentication.save
-      return redirect_to new_user_session_path, alert: t("defaults.flash_message.omniauth_callback.auth_save_failure")
+    ActiveRecord::Base.transaction do
+      # ユーザー登録
+      user.save!
+      # user_id、provider、uidの登録
+      authentication.user = user
+      authentication.save!
     end
     sign_in(:user, authentication.user)
     redirect_to home_path, notice: t("devise.registrations.signed_up")
+
+    # 登録時、すでに同じメールアドレスが登録されている場合、ここでキャッチされる
+    rescue ActiveRecord::RecordInvalid => e
+      Rails.logger.error(I18n.t("defaults.omniauth_error_log", error_class: e.class, error_message: e.message))
+      redirect_to new_user_registration_path, alert: e.message
+    # 予期せぬエラー
+    rescue => e
+      Rails.logger.error(I18n.t("defaults.omniauth_unexpected_error_log", error_class: e.class, error_message: e.message))
+      redirect_to new_user_registration_path, alert: t("defaults.unexpected_error")
   end
 
   # ログイン用

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -16,6 +16,9 @@ ja:
     delete_confirm: 本当に削除してよろしいですか？
     confirm_error_log: "メール認証エラー：%{error}"
     confirm_error: メール認証中にエラーが発生しました。再度確認メールを送信をしてください。
+    omniauth_error_log: "SNSアカウント登録エラー Class：%{error_class}, Message：%{error_message}"
+    omniauth_unexpected_error_log: "SNSアカウント登録での予期せぬエラー Class：%{error_class}, Message：%{error_message}"
+    unexpected_error: アカウント登録中にエラーが発生しました。時間をおいてから再度、登録をお試しください。
     flash_message:
       created: 登録しました
       not_created: 登録できませんでした


### PR DESCRIPTION
## 概要
SNSアカウントでの登録処理にトランザクション処理を実装しました

## 背景
以前の実装だと登録時にエラーが発生するとユーザー情報だけが保存され、SNSアカウント情報と紐づかない可能性があったため

## 該当Issue
- #216 

## 変更内容
- SNSアカウントでの登録処理をトランザクションでラップするよう修正

## 確認方法
※環境構築は完了している前提
1. transaction内で例外が発生するケース（例：バリデーションエラーを発生させるために同じメールアドレスのアカウントを先に作っておく）を再現する
2. SNSアカウント（今回はLINE）で登録する
3. ユーザーが作成されておらず、ロールバックしていることを確認
4. 新規登録画面にリダイレクトされることを確認

## 補足
- 特記事項はございません