### PR TITLE
chore: ciにRSpecを実行するよう設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
-        run: bundle exec rspec
+        run: bin/rails db:test:prepare && bundle exec rspec
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 概要
ciにRSpecを実行するよう設定しました

## 背景
プルリクエスト時に自動でテストするようにするため

## 該当Issue
- #161 

## 変更内容
- `.github\workflows\ci.yml`にRSpec実行コマンドを追加

## 確認方法
※環境構築は完了している前提
1. GithubにてプルリクエストしたときにRSpecが実行されていること
<img width="697" height="428" alt="image" src="https://github.com/user-attachments/assets/2b6fa85a-979e-466c-9174-7217ad8c3899" />

## 補足
- 特記事項はございません