### PR TITLE
fix: figures_controllerのshowアクションの修正

### DIFF
--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -29,7 +29,7 @@ class FiguresController < ApplicationController
   end
 
   def show
-    @figure = Figure.find(params[:id])
+    @figure = current_user.figures.find(params[:id])
   end
 
   def edit


### PR DESCRIPTION
## 概要
figures_controllerのshowアクションの修正をしました

## 背景
URLから他人のフィギュアIDを入れることで自分のもの以外も閲覧可能だったため

## 該当Issue
- #235 

## 変更内容
- `figures_controller`の`show`アクションの修正

## 確認方法
※環境構築は完了している前提
1. Aユーザー、Bユーザーの2アカウントを作成する
2. 2アカウントでフィギュアを1個ずつ作成する
3. Aユーザーでログインして、Bユーザーで作成したフィギュアIDをURLで指定しても閲覧できないことを確認

## 補足
- 特記事項はございません