### PR TITLE
fix: 支払いステータスの自動更新の条件を修正

### DIFF
--- a/lib/tasks/update_payment_status.rake
+++ b/lib/tasks/update_payment_status.rake
@@ -1,7 +1,7 @@
 namespace :payment_status do
   desc "発売月が翌月を迎えた場合、支払いステータスを自動で「支払い済み」に変更する"
   task update_payment_status: :environment do
-    Figure.unpaid.where("release_month < ?", Date.current).find_each do |figure|
+    Figure.unpaid.where("release_month < ?", Date.current.beginning_of_month).find_each do |figure|
       retry_count = 0
       begin
         retry_count += 1


### PR DESCRIPTION
## 概要
支払いステータスの自動更新の条件を修正しました

## 背景
発売月と今月が同じの時、2日以降になったら全て支払い済みに更新されてしまうため

## 該当Issue
- #242 

## 変更内容
- `lib\tasks\update_payment_status.rake`の条件を修正

## 確認方法
※環境構築は完了している & ログインしている前提
1. `docker compose exec web bundle exec rails payment_status:update_payment_status`本コマンドを実行する
2. 発売月が今月より小さいときだけ支払いステータスが更新されることを確認

## 補足
- 特記事項はございません