### PR TITLE
feat: 月ごとのフィギュア個数を表示する棒グラフを追加

### DIFF
--- a/app/javascript/controllers/monthly_chart_controller.js
+++ b/app/javascript/controllers/monthly_chart_controller.js
@@ -4,7 +4,8 @@ import Chart from "chart.js/auto"
 export default class extends Controller {
   static values = {
     labels: Array,
-    data: Array
+    unpaidData: Array,
+    quantityData: Array
   }
   connect() {
     const isMobile = window.innerWidth < 768
@@ -14,24 +15,50 @@ export default class extends Controller {
       data: {
         labels: this.labelsValue,
         datasets: [{
-          label: '未払いの合計',
-          data: this.dataValue
+          label: "未払いの合計",
+          data: this.unpaidDataValue,
+          yAxisID: "y1"
+        },
+        {
+          label: "個数",
+          data: this.quantityDataValue,
+          yAxisID: "y2"
         }]
       },
       options: {
         // canvasのCSSの高さに従わせる
         maintainAspectRatio: false, 
+        animation: false,
         scales: {
-         x: {
+          // 下：月ラベル
+          x: {
             ticks: {
-            font: { size: isMobile ? 8 : 12 }
+              // ラベルの文字の大きさの調整
+              font: { size: isMobile ? 8 : 12 }
             }
-        },
-        y: {
+          },
+          // 左：金額ラベル
+          y1: {
             ticks: {
-            font: { size: isMobile ? 8 : 12 }
+              // ラベルの文字の大きさの調整
+              font: { size: isMobile ? 8 : 12 }
             }
-        }
+          },
+          // 右：個数ラベル
+          y2: {
+            ticks: {
+              // ラベルの文字の大きさの調整
+              font: { size: isMobile ? 8 : 12 },
+              // 整数刻みにする
+              stepSize: 1
+            },
+            // ラベルをグラフの右に配置
+            position: "right",
+            // 個数のY軸グラフの横線を表示しない
+            grid: {
+              drawOnChartArea: false
+            }
+          }
         }
       }
     })

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -10,7 +10,8 @@
         <canvas
             data-controller="monthly-chart"
             data-monthly-chart-labels-value="<%= @labels.to_json %>"
-            data-monthly-chart-data-value="<%= @data.to_json %>">
+            data-monthly-chart-unpaid-data-value="<%= @unpaid_total_data.to_json %>"
+            data-monthly-chart-quantity-data-value="<%= @quantity_data.to_json %>">
         </canvas>
       </div>
     </div>


### PR DESCRIPTION
## 概要
月ごとのフィギュア個数を表示する棒グラフを追加しました

## 背景
もし支払いステータスが支払い済みの場合、グラフからは何も予約していないように見えるため

## 該当Issue
- #259 

## 変更内容
- `monthly_chart_controller.js`を個数のグラフを表示するよう改修
- `home_controller.rb`で個数グラフ用のデータを作成
- `home/index.html.rb`に個数用のデータを渡すよう改修

## 確認方法
※環境構築は完了している & ログインしている前提
1. 個数を表示する棒グラフが表示されていることを確認
<img width="2142" height="1887" alt="image" src="https://github.com/user-attachments/assets/88a43d73-61a0-48a7-b2a2-730b01f20e8a" />

## 補足
- 特記事項はございません