### PR TITLE
デプロイのため develop を main にマージ（OGP（twitter-card）を設定）

### DIFF
--- a/app/views/figures/_form.html.erb
+++ b/app/views/figures/_form.html.erb
@@ -11,7 +11,7 @@
     <!-- 発売月 -->
     <div>
       <%= f.label :release_month, class: "font-bold"  %>
-      <%= f.month_field :release_month, min: Time.current,
+      <%= f.month_field :release_month,
             class: "w-full rounded-lg border border-gray-500 p-2 hover:border-gray-400" %>
     </div>
     <!-- 個数 -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,11 @@
     <meta property="og:url" content="https://figrune-app.com" />
     <meta property="og:image" content="<%= image_url('OGP.png') %>" />
 
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Figrune" />
+    <meta name="twitter:description" content="将来の支払い・発売時期を一括管理し、フィギュアの予約・購入をより快適にします。" />
+    <meta name="twitter:image" content="<%= image_url('OGP.png') %>" />
+
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- OGP（twitter-card）を設定
- 登録、編集時の発売月のminを削除

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] XにアプリのURLを張った際にOGPが表示されていること
- [x] フィギュアの登録、編集時に過去の月も選択できること 

## 補足
- 特記事項はございません