### PR TITLE
fix: og:urlの末尾に「/」を追記

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <meta property="og:title" content="Figrune" />
     <meta property="og:description" content="将来の支払い・発売時期を一括管理し、フィギュアの予約・購入をより快適にします。" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://figrune-app.com" />
+    <meta property="og:url" content="https://figrune-app.com/" />
     <meta property="og:image" content="<%= image_url('OGP.png') %>" />
 
     <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
## 概要
`og:url`の末尾に「/」を追記しました

## 背景
「/」つけている方が正しいため

## 該当Issue
- #272 

## 変更内容
- `og:url`の末尾に「/」を追記

## 確認方法
開発環境では確認できないため、本番環境にて確認します

## 補足
- 特記事項はございません