### PR TITLE
fix: 「発売予定」「発売済み」ラベルの更新ロジックを修正

### DIFF
--- a/app/helpers/figures_helper.rb
+++ b/app/helpers/figures_helper.rb
@@ -7,7 +7,7 @@ module FiguresHelper
   end
 
   def release_label(figure)
-    if figure.release_month < Date.current
+    if figure.release_month < Date.current.beginning_of_month
       t(".released")
     else
       t(".upcoming")


### PR DESCRIPTION
## 概要
「発売予定」「発売済み」ラベルの更新ロジックを修正しました

## 背景
2日になった時点で「発売済み」となってしまっていたため

## 該当Issue
- #276 

## 変更内容
- `figures_helper.rb`の更新ロジックを修正

## 確認方法
※環境構築は完了している & ログインしている前提
1. 発売月と同じ月でも「発売予定」のままになっていることを確認
<img width="2142" height="1887" alt="image" src="https://github.com/user-attachments/assets/85fdcb0c-620e-4b21-a28b-bfb97afc313c" />

2. 発売月のよく月になった場合、「発売済み」になっていることを確認
<img width="2142" height="1887" alt="image" src="https://github.com/user-attachments/assets/bea1bb20-03f4-4a1a-9c84-3d1139764ac3" />


## 補足
- 特記事項はございません