### PR TITLE
デプロイのため develop を main にマージ（「発売予定/済み」のラベル更新ロジックの変更、戻るボタンの修正/削除）

### DIFF
--- a/app/controllers/figures_controller.rb
+++ b/app/controllers/figures_controller.rb
@@ -52,7 +52,9 @@ class FiguresController < ApplicationController
     @figure.assign_shop_by_name(@figure.shop_name)
     @figure.assign_manufacturer_by_name(@figure.manufacturer_name)
     if @figure.save
-      redirect_to figure_path(@figure), notice: t("defaults.flash_message.updated")
+      safe_origin_path = helpers.safe_back_path(params[:back_to])
+      # _form.html.erbで保持していた遷移元のURLを詳細画面に渡す
+      redirect_to figure_path(@figure, back_to: safe_origin_path), notice: t("defaults.flash_message.updated")
     else
       flash.now[:alert] = t("defaults.flash_message.not_updated")
       render :edit, status: :unprocessable_entity

--- a/app/helpers/figures_helper.rb
+++ b/app/helpers/figures_helper.rb
@@ -13,4 +13,24 @@ module FiguresHelper
       t(".upcoming")
     end
   end
+
+  # XSS対策
+  def safe_back_path(path)
+    # pathが空、または JavaScript: で始まるような怪しい文字列ならホーム画面へ
+    return home_path if path.blank? || path.start_with?("javascript:")
+
+    # 自分のサイトのURL（絶対URL）なら許可してそのまま返す
+    # request.base_url はドメイン部分を取得する
+    if path.start_with?(request.base_url)
+      return path
+    end
+
+    # 相対パス（/から始まる）なら許可
+    if path.start_with?("/") && !path.start_with?("//")
+      return path
+    end
+
+    # それ以外はホーム画面へ
+    home_path
+  end
 end

--- a/app/views/account_settings/show.html.erb
+++ b/app/views/account_settings/show.html.erb
@@ -40,9 +40,4 @@
       </dd>
     </div>
   </dl>
-  <div class="max-w-sm mx-auto flex flex-col">
-    <!-- 戻るボタン -->
-    <%= link_to t(".back"), figures_path,
-        class: "mt-3 mb-10 px-18 py-2 text-center rounded-lg bg-gray-500 text-white font-semibold hover:bg-gray-600 transition" %>
-  </div>
 </div>

--- a/app/views/figures/_form.html.erb
+++ b/app/views/figures/_form.html.erb
@@ -1,6 +1,8 @@
 <%= form_with model: figure do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
   <div class="flex flex-col gap-3">
+    <!-- show.html.erbの編集ボタンで渡した遷移元のURLを保持しておく -->
+    <%= hidden_field_tag :back_to, safe_back_path(params[:back_to]) %>
     <!-- 商品名 -->
     <div>
       <%= f.label :name, class: "font-bold" %>

--- a/app/views/figures/show.html.erb
+++ b/app/views/figures/show.html.erb
@@ -82,11 +82,17 @@
     </div>
   <% end %>
   <div class="max-w-sm mx-auto flex flex-col">
+    <!-- 戻るボタンで遷移元に戻るための変数であり、一覧⇒詳細⇒編集（更新）⇒詳細⇒戻る⇒編集になることを防ぐため
+    初めて詳細に来た時、request.refererで一覧orホームのpathが変数に入り、
+    編集（更新）をして詳細に戻ってきても、戻るを押すと遷移元（一覧orホーム）に戻ることができる -->
+    <% origin_path = params[:back_to] || request.referer || home_path %>
+    <% safe_origin_path = safe_back_path(origin_path)%>
     <!-- 編集するボタン -->
-    <%= link_to t(".edit"), edit_figure_path(@figure),
+    <!-- パスに遷移元のURLを渡しておく -->
+    <%= link_to t(".edit"), edit_figure_path(@figure, back_to: safe_origin_path),
         class: "mt-3 mb-3 px-18 py-2 text-center rounded-lg bg-indigo-600 text-white font-semibold hover:bg-indigo-700 transition" %>
     <!-- 戻るボタン -->
-    <%= link_to t(".back"), figures_path,
+    <%= link_to t(".back"), safe_origin_path,
         class: "mt-3 mb-10 px-18 py-2 text-center rounded-lg bg-gray-500 text-white font-semibold hover:bg-gray-600 transition" %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- 「発売予定」「発売済み」のラベルの更新ロジックの変更
- アカウント設定画面の戻るボタンを削除
- 詳細画面で遷移元を保持し、更新後も遷移元へ戻れるように修正

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] 発売月の翌月になった場合、「発売済み」になり、それ以外は「発売予定」になっていること
- [x] アカウント設定画面の戻るボタンが削除されていること
- [x] 詳細画面から編集画面に遷移し、データ更新後も遷移元へ戻れるようになっていること

## 補足
- 特記事項はございません