### PR TITLE
chore: CIのactions/checkoutをv6に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -26,7 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -67,7 +68,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install --no-install-recommends -y google-chrome-stable curl libjemalloc2 libvips postgresql-client
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## 概要
CIのactions/checkoutをv6に更新しました

## 背景
dependabotの提案に対応するため

## 該当Issue
- なし

## 変更内容
- actions/checkoutをv4 ⇒ v6に更新

## 確認方法
※環境構築は完了している前提
1. CIが問題なく動くこと

## 補足
- 特記事項はございません