### PR TITLE
chore: pumaを7.2.0に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       date
       stringio
     public_suffix (7.0.2)
-    puma (7.1.0)
+    puma (7.2.0)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.5)


### PR DESCRIPTION
## 概要
pumaを7.2.0に更新しました

## 背景
dependabotの提案に対応するため

## 該当Issue
- なし

## 変更内容
- pumaを`7.1.0`から`7.2.0`に更新

## 確認方法
※環境構築は完了している前提
1. RSpec、CI（test）で問題がないこと

## 補足
- 特記事項はございません