### PR TITLE
デプロイのため develop を main にマージ（pumaを更新）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       date
       stringio
     public_suffix (7.0.2)
-    puma (7.1.0)
+    puma (7.2.0)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.5)


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- pumaのアップデート

## 動作確認
- [x] 既存の機能に問題がないこと

## 補足
- 特記事項はございません