### PR TITLE
chore: actions/setup-nodeをv6に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'yarn'


### PR DESCRIPTION
## 概要
actions/setup-nodeをv6に更新しました

## 背景
dependabotの提案に対応するため

## 該当Issue
- なし

## 変更内容
- actions/setup-nodeを`v4`から`v6`に更新

## 確認方法
※環境構築は完了している前提
1. CI（test）で問題がないこと

## 補足
- 特記事項はございません