### PR TITLE
デプロイのため develop を main にマージ（actions/setup-nodeを更新）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           bundler-cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'yarn'


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- actions/setup-nodeのアップデート

## 動作確認
- [x] 既存の機能に問題がないこと

## 補足
- 特記事項はございません