### PR TITLE
fix: workflowのkeyErrorの修正

### DIFF
--- a/.github/workflows/update_payment_status.yml
+++ b/.github/workflows/update_payment_status.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # GithubActionsの仮想環境用のディレクトリにリポジトリのクローン
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Rubyのセットアップ
       - name: Set up Ruby


### PR DESCRIPTION
## 概要
workflowのkeyErrorの修正をしました

## 背景
GithubActionsでkeyErrorが発生していたため

## 該当Issue
- #294 

## 変更内容
- 支払いステータスを更新するworkflowの`env:`を修正
- actions/checkoutを`v4`から`v6`に更新

## 確認方法
本番環境にデプロイ後に確認します

## 補足
- 特記事項はございません