### PR TITLE
デプロイのため develop を main にマージ（支払いステータスを自動更新するworkflowの修正）

### DIFF
--- a/.github/workflows/update_payment_status.yml
+++ b/.github/workflows/update_payment_status.yml
@@ -13,12 +13,17 @@ jobs:
     env:
       RAILS_ENV: production
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      MAIL_FROM: ${{ secrets.MAIL_FROM }}
       SECRET_KEY_BASE: ${{ secrets.SECRET_KEY_BASE }}
+      LINE_KEY: ${{ secrets.LINE_KEY }}
+      LINE_SECRET: ${{ secrets.LINE_SECRET }}
+      LINE_CHANNEL_TOKEN: ${{ secrets.LINE_CHANNEL_TOKEN }}
     
     steps:
       # GithubActionsの仮想環境用のディレクトリにリポジトリのクローン
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Rubyのセットアップ
       - name: Set up Ruby


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- 支払いステータスを自動更新するworkflowの修正

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] GithubのActionsで`update_payment_status`を手動実行し、エラーが出ないこと

## 補足
- 特記事項はございません