### PR TITLE
chore: actions/upload-artifactをv7に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         run: bin/rails db:test:prepare && bundle exec rspec
 
       - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: screenshots


### PR DESCRIPTION
## 概要
actions/upload-artifactを`v7`に更新しました

## 背景
dependabotの提案に対応するため

## 該当Issue
- なし

## 変更内容
- actions/upload-artifactを`v4`から`v7`に更新

## 確認方法
※環境構築は完了している前提
1. RSpec、CI（test）で問題がないこと

## 補足
- 特記事項はございません