### PR TITLE
chore: figure_payment_notificationのactions/checkoutをv6に更新

### DIFF
--- a/.github/workflows/figure_payment_notification.yml
+++ b/.github/workflows/figure_payment_notification.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # GithubActionsの仮想環境用のディレクトリにリポジトリのクローン
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Rubyのセットアップ
       - name: Set up Ruby


### PR DESCRIPTION
## 概要
`figure_payment_notification`の`actions/checkout`を`v6`に更新しました

## 背景
dependabotの提案に対応するため

## 該当Issue
- なし

## 変更内容
- `actions/checkout`を`v4`から`v6`に更新

## 確認方法
本番環境にデプロイ後に確認します

## 補足
- 特記事項はございません