### PR TITLE
chore: resendを1.0.1に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,7 +306,7 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
-    resend (1.0.0)
+    resend (1.0.1)
       httparty (>= 0.21.0)
     responders (3.2.0)
       actionpack (>= 7.0)


### PR DESCRIPTION
## 概要
resendを`1.0.1`に更新しました

## 背景
dependabotの提案に対応するため

## 該当Issue
- なし

## 変更内容
- resendを`1.0.0`から`1.0.1`に更新

## 確認方法
※環境構築は完了している前提
1. RSpec、CI（test）で問題がないこと
2. メールの送信ができていること

## 補足
- 特記事項はございません