### PR TITLE
chore: devise-i18nを1.16.0に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,8 +113,8 @@ GEM
       railties (>= 7.0)
       responders
       warden (~> 1.2.3)
-    devise-i18n (1.15.0)
-      devise (>= 4.9.0)
+    devise-i18n (1.16.0)
+      devise (>= 5.0.0)
       rails-i18n
     diff-lcs (1.6.2)
     drb (2.2.3)


### PR DESCRIPTION
## 概要
devise-i18nを`1.16.0`に更新しました

## 背景
dependabotの提案に対応するため

## 該当Issue
- なし

## 変更内容
- devise-i18nを`1.15.0`から`1.16.0`に更新

## 確認方法
※環境構築は完了している前提
1. RSpec、CI（test）で問題がないこと
2. 認証画面の日本語表示に問題がないこと

## 補足
- 翻訳ファイルのみの更新のため、認証ロジックへの影響はありません