### PR TITLE
feat: アカウント削除機能の追加

### DIFF
--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -64,6 +64,8 @@ class AccountSettingsController < ApplicationController
     end
   end
 
+  def confirm_destroy; end
+
   private
 
   def set_user

--- a/app/javascript/controllers/account_delete_controller.js
+++ b/app/javascript/controllers/account_delete_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["checkbox", "button"]
+
+  connect() {
+    this.toggleButton()
+  }
+
+  toggleButton() {
+    this.buttonTarget.disabled = !this.checkboxTarget.checked
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,3 +10,5 @@ import MonthlyChartController from "./monthly_chart_controller"
 application.register("monthly-chart", MonthlyChartController)
 import DateRangeController from "./date_range_controller"
 application.register("date-range", DateRangeController)
+import AccountDeleteController from "./account_delete_controller"
+application.register("account-delete", AccountDeleteController)

--- a/app/views/account_settings/confirm_destroy.html.erb
+++ b/app/views/account_settings/confirm_destroy.html.erb
@@ -1,0 +1,25 @@
+<% content_for(:title, t(".title")) %>
+<div class="min-h-screen flex items-center justify-center px-4">
+  <div class="w-full max-w-md bg-gray-100 rounded-2xl shadow-md p-8">
+    <h2 class="text-2xl font-bold text-center text-gray-800 mb-6">
+      <%= t(".title") %>
+    </h2>
+
+    <div class="space-y-6">
+
+    <!-- 説明 -->
+    <div class="text-sm">
+      <%= t(".description") %>
+    </div>
+
+      <%= check_box_tag :test1 %>
+      <%= label_tag :test1, "上記内容を理解しました" %>
+
+    <!-- 削除ボタン -->
+    <div>
+      <%= button_to "アカウント削除", registration_path(@user), data: { confirm: t(".confirm"), turbo_confirm: t(".confirm") },
+         method: :delete, class: "w-full py-2.5 rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition" %>
+    </div>
+    </div>
+  </div>
+</div>

--- a/app/views/account_settings/confirm_destroy.html.erb
+++ b/app/views/account_settings/confirm_destroy.html.erb
@@ -5,21 +5,26 @@
       <%= t(".title") %>
     </h2>
 
-    <div class="space-y-6">
+    <div class="space-y-6" data-controller="account-delete">
 
-    <!-- 説明 -->
-    <div class="text-sm">
-      <%= t(".description") %>
-    </div>
+      <!-- 説明 -->
+      <div class="text-sm">
+        <%= t(".description") %>
+      </div>
 
-      <%= check_box_tag :test1 %>
-      <%= label_tag :test1, "上記内容を理解しました" %>
+      <!-- 上記の内容を理解しましたチェックボックス -->
+      <div>
+        <!-- ここの「１」に意味はない。しかし、削除すると引数のずれが発生するため削除は非推奨 -->
+        <%= check_box_tag :confirm, "1", false, data: { account_delete_target: "checkbox", action: "change->account-delete#toggleButton" } %>
+        <%= label_tag :confirm, t(".confirm_understanding") %>
+      </div>
 
-    <!-- 削除ボタン -->
-    <div>
-      <%= button_to "アカウント削除", registration_path(@user), data: { confirm: t(".confirm"), turbo_confirm: t(".confirm") },
-         method: :delete, class: "w-full py-2.5 rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition" %>
-    </div>
+      <!-- 削除ボタン -->
+      <%= button_to t(".delete"), registration_path(@user), data: { confirm: t(".delete_confirm"), turbo_confirm: t(".delete_confirm"), account_delete_target: "button" },
+          method: :delete,
+          disabled: true,
+          class: "w-full py-2.5 rounded-lg font-semibold transition bg-red-600 text-white hover:bg-red-700 disabled:bg-gray-400 disabled:cursor-not-allowed" %>
+
     </div>
   </div>
 </div>

--- a/app/views/account_settings/show.html.erb
+++ b/app/views/account_settings/show.html.erb
@@ -53,4 +53,21 @@
     </div>
   
   </dl>
+
+  <!-- 管理 -->
+  <h3 class="text-xl font-bold border-b-2 pb-1 mt-12">
+    <%= t(".management") %>
+  </h3>
+  
+  <dl class="my-3 divide-y divide-gray-400">
+  
+    <!-- アカウント削除 -->
+    <div class="grid grid-cols-2 py-3 sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".delete_account") %></dt>
+      <dd class="text-gray-700 sm:col-span-2">
+        <%= link_to t(".confirm_destroy"), confirm_destroy_account_setting_path, class: "text-red-500 hover:underline font-medium"%>
+      </dd>
+    </div>
+  
+  </dl>
 </div>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -140,7 +140,9 @@ ja:
       notification_setting: 通知設定
       email_notification: メール通知
       line_notification: LINE通知
-      back: 戻る
+      management: 管理
+      delete_account: アカウント削除
+      confirm_destroy: 削除手続き
     edit_email:
       title: "メールアドレス%{action_word}"
       current_email: 現在のメールアドレス
@@ -166,5 +168,7 @@ ja:
       failure: 予期せぬエラーで通知設定を変更できませんでした
     update_line_notification_timing:
       failure: 予期せぬエラーで通知設定を変更できませんでした
-      
-
+    confirm_destroy:
+      title: アカウント削除
+      description: アカウントを削除すると、登録したデータはすべて削除されます。問題ない方は下記のチェックボックスにチェックをして削除してください。
+      confirm: 本当に削除しますか？

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -171,4 +171,6 @@ ja:
     confirm_destroy:
       title: アカウント削除
       description: アカウントを削除すると、登録したデータはすべて削除されます。問題ない方は下記のチェックボックスにチェックをして削除してください。
-      confirm: 本当に削除しますか？
+      confirm_understanding: 上記の内容を理解しました
+      delete_confirm: アカウントを削除してよろしいですか？
+      delete: 削除する

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     patch :update_password
     patch :update_email_notification_timing
     patch :update_line_notification_timing
+    get   :confirm_destroy
   end
   devise_for :users, controllers: {
     registrations: "users/registrations",

--- a/spec/system/account_settings_spec.rb
+++ b/spec/system/account_settings_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe "AccountSettings", type: :system do
         expect(page).to have_content('ログインもしくはアカウント登録してください。')
         expect(current_path).to eq new_user_session_path
       end
+
+      it 'アカウント削除画面へのアクセスに失敗する' do
+        visit confirm_destroy_account_setting_path
+        expect(page).to have_content('ログインもしくはアカウント登録してください。')
+        expect(current_path).to eq new_user_session_path
+      end
     end
   end
 
@@ -77,6 +83,12 @@ RSpec.describe "AccountSettings", type: :system do
           expect(page).to have_content('パスワード設定')
           expect(page).to have_current_path(edit_password_account_setting_path)
         end
+      end
+
+      it 'アカウント削除画面にアクセスできる' do
+        click_link '削除手続き'
+        expect(page).to have_content('アカウント削除')
+        expect(page).to have_current_path(confirm_destroy_account_setting_path)
       end
     end
 
@@ -313,6 +325,23 @@ RSpec.describe "AccountSettings", type: :system do
         expect(page).to have_content('1週間前')
         user.reload
         expect(user.line_notification_timing).to eq 'one_week_before'
+      end
+    end
+
+    context '管理' do
+      before do
+        visit confirm_destroy_account_setting_path
+      end
+      it 'アカウント削除ができること' do
+        check '上記の内容を理解しました'
+        click_button '削除する'
+        expect(page.accept_confirm).to eq 'アカウントを削除してよろしいですか？'
+        expect(page).to have_content 'アカウントを削除しました。またのご利用をお待ちしております。'
+        expect(current_path).to eq root_path
+      end
+
+      it 'アカウント削除ができないこと' do
+        expect(page).to have_button('削除する', disabled: true)
       end
     end
   end


### PR DESCRIPTION
## 概要
アカウント削除機能を実装しました

## 背景
ユーザー自身でアカウント削除できるようにするため

## 該当Issue
- #331 

## 変更内容
- アカウント削除画面を表示するアクションをコントローラーに追加
- アカウント削除画面を作成
- 削除ボタンを入力内容に応じて活性化するJSを作成
- アカウント削除用のシステムスペックを追加

## 確認方法
※環境構築は完了している & ログインしている前提
1. ヘッダーの`アカウント設定`をクリックし、アカウント削除欄が表示されていることを確認
<img width="2142" height="1887" alt="image" src="https://github.com/user-attachments/assets/a69e892b-51d0-4fde-a7ae-eaffaf9223b3" />

2. `削除手続きへ`をクリックでアカウント削除画面が表示されることを確認
<img width="2142" height="1887" alt="image" src="https://github.com/user-attachments/assets/1d228e9c-8d21-444d-bb03-59f094446fca" />

3. アカウント削除できることを確認
<img width="2142" height="1887" alt="image" src="https://github.com/user-attachments/assets/f1790bda-1963-41d1-a48c-2b3c9d53f554" />

## 補足
- 特記事項はございません