### PR TITLE
デプロイのため develop を main にマージ（line-bot-apiを更新）

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
-    line-bot-api (2.6.1)
+    line-bot-api (2.7.0)
       base64 (~> 0.2)
       multipart-post (~> 2.4)
     lint_roller (1.1.0)


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- line-bot-apiを`2.6.1`から`2.7.0`に更新

## 動作確認
- [x] 既存の機能に問題がないこと

## 補足
- 特記事項はございません