### PR TITLE
chore: bootsnapを1.23.0から1.24.4に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
-    bootsnap (1.23.0)
+    bootsnap (1.24.4)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc


### PR DESCRIPTION
## 概要
bootsnapを`1.23.0`から`1.24.4`に更新しました

## 背景
dependabotの提案に対応するため

## 該当Issue
- なし

## 変更内容
- bootsnapを`1.23.0`から`1.24.4`に更新

## 確認方法
※環境構築は完了している前提
1. RSpec、CI（test）で問題がないこと

## 補足
- 特記事項はございません