### PR TITLE
デプロイのため develop を main にマージ（LINE連携機能を追加）

### DIFF
--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -64,7 +64,15 @@ class AccountSettingsController < ApplicationController
     end
   end
 
+  # アカウント削除時に実行
   def confirm_destroy; end
+
+  # LINE連携解除時に実行
+  def line_unlink
+    return redirect_to account_setting_path, alert: t(".failure") if @user.has_email == false || @user.has_password == false
+    @user.authentications.find_by(provider: "line")&.destroy
+    redirect_to account_setting_path, notice: t(".unlinked"), status: :see_other
+  end
 
   private
 

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -61,7 +61,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def link_account(authentication)
     # LINEアカウントがすでにほかのアカウントと紐づいている、またはアカウントとして存在している場合はフラッシュメッセージを表示
     return redirect_to account_setting_path, alert: t("omniauth_callbacks.link_account.exist_line_account") if authentication.user.present?
-    
+
     authentication.user = current_user
     if authentication.save
       redirect_to account_setting_path, notice: t("omniauth_callbacks.link_account.success")

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -14,8 +14,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     # 認証情報の検索
     @authentication = Authentication.find_or_initialize_by(provider: @omniauth["provider"], uid: @omniauth["uid"])
 
-    # 認証情報にuser_idがあればログイン、なければ新規登録
-    if @authentication.user.blank?
+    # ログイン済みなら連携、認証情報にuser_idがあればログイン、なければ新規登録
+    if user_signed_in?
+      link_account(@authentication)
+    elsif @authentication.user.blank?
       register_external_user(@omniauth, @authentication)
     else
       authenticate_external_user(@omniauth, @authentication)
@@ -53,5 +55,18 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def authenticate_external_user(omniauth, authentication)
     sign_in(:user, authentication.user)
     redirect_to home_path, notice: t("devise.sessions.signed_in")
+  end
+
+  # 連携用
+  def link_account(authentication)
+    # LINEアカウントがすでにほかのアカウントと紐づいている、またはアカウントとして存在している場合はフラッシュメッセージを表示
+    return redirect_to account_setting_path, alert: t("omniauth_callbacks.link_account.exist_line_account") if authentication.user.present?
+    
+    authentication.user = current_user
+    if authentication.save
+      redirect_to account_setting_path, notice: t("omniauth_callbacks.link_account.success")
+    else
+      redirect_to account_setting_path, alert: t("omniauth_callbacks.link_account.failure")
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,4 +54,8 @@ class User < ApplicationRecord
       errors.add(:base, I18n.t("defaults.confirm_error"))
       false
   end
+
+  def line_linked?
+    authentications.exists?(provider: "line")
+  end
 end

--- a/app/views/account_settings/show.html.erb
+++ b/app/views/account_settings/show.html.erb
@@ -54,6 +54,35 @@
   
   </dl>
 
+  <!-- 連携 -->
+  <h3 class="text-xl font-bold border-b-2 pb-1 mt-12">
+    <%= t(".link") %>
+  </h3>
+
+  <dl class="my-3 divide-y divide-gray-400">
+  
+    <!-- LINE連携 -->
+    <div class="grid grid-cols-2 py-3 items-center sm:grid-cols-3">
+      <dt class="font-bold"><%= t(".line_link") %></dt>
+      <dd class="text-gray-700 sm:col-span-2">
+      <% if current_user.line_linked? %>
+        <span>
+          <%= t(".line_link_cancel") %>
+        </span>
+      <% else %>
+        <%= button_to user_line_omniauth_authorize_path,
+                      class: "text-[#06C755] hover:underline font-medium",
+                      data: { turbo: false } do %>
+          <span>
+            <%= t(".line_link") %>
+          </span>
+        <% end %>
+      <% end %>
+      </dd>
+    </div>
+  
+  </dl>
+
   <!-- 管理 -->
   <h3 class="text-xl font-bold border-b-2 pb-1 mt-12">
     <%= t(".management") %>

--- a/app/views/account_settings/show.html.erb
+++ b/app/views/account_settings/show.html.erb
@@ -63,12 +63,11 @@
   
     <!-- LINE連携 -->
     <div class="grid grid-cols-2 py-3 items-center sm:grid-cols-3">
-      <dt class="font-bold"><%= t(".line_link") %></dt>
+      <dt class="font-bold"><%= t(".line") %></dt>
       <dd class="text-gray-700 sm:col-span-2">
       <% if current_user.line_linked? %>
-        <span>
-          <%= t(".line_link_cancel") %>
-        </span>
+        <%= link_to t(".line_unlink"), line_unlink_account_setting_path, data: { turbo_method: :delete, turbo_confirm: t(".unlink_confirm") },
+            class: "text-gray-500 hover:underline font-medium" %>
       <% else %>
         <%= button_to user_line_omniauth_authorize_path,
                       class: "text-[#06C755] hover:underline font-medium",

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -177,3 +177,8 @@ ja:
       confirm_understanding: 上記の内容を理解しました
       delete_confirm: アカウントを削除してよろしいですか？
       delete: 削除する
+  omniauth_callbacks:
+    link_account:
+      success: LINE連携が完了しました
+      failure: LINE連携中にエラーが発生しました、もう一度お試しください
+      exist_line_account: そのLINEアカウントはすでに存在しています

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -144,8 +144,10 @@ ja:
       delete_account: アカウント削除
       confirm_destroy: 削除手続き
       link: 連携
+      line: LINE
       line_link: LINE連携
-      line_link_cancel: LINE連携解除
+      line_unlink: LINE連携解除
+      unlink_confirm: LINE連携を解除してよろしいですか？
     edit_email:
       title: "メールアドレス%{action_word}"
       current_email: 現在のメールアドレス
@@ -177,6 +179,9 @@ ja:
       confirm_understanding: 上記の内容を理解しました
       delete_confirm: アカウントを削除してよろしいですか？
       delete: 削除する
+    line_unlink:
+      unlinked: LINE連携を解除しました
+      failure: LINEでログイン中のため解除できません
   omniauth_callbacks:
     link_account:
       success: LINE連携が完了しました

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -143,6 +143,9 @@ ja:
       management: 管理
       delete_account: アカウント削除
       confirm_destroy: 削除手続き
+      link: 連携
+      line_link: LINE連携
+      line_link_cancel: LINE連携解除
     edit_email:
       title: "メールアドレス%{action_word}"
       current_email: 現在のメールアドレス

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     patch :update_email_notification_timing
     patch :update_line_notification_timing
     get   :confirm_destroy
+    delete :line_unlink
   end
   devise_for :users, controllers: {
     registrations: "users/registrations",

--- a/spec/system/account_settings_spec.rb
+++ b/spec/system/account_settings_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe "AccountSettings", type: :system do
         click_button 'LINE連携'
         expect(current_path).to eq account_setting_path
       end
-      
+
       # ログイン手段がLINEしかない場合、解除できるとログインできなくなるため
       it 'LINE連携解除ができないこと' do
         logout

--- a/spec/system/account_settings_spec.rb
+++ b/spec/system/account_settings_spec.rb
@@ -328,6 +328,62 @@ RSpec.describe "AccountSettings", type: :system do
       end
     end
 
+    context '連携' do
+      before do
+        login_as(user)
+        line_mock
+      end
+      it 'LINE連携ができること' do
+        visit account_setting_path
+        click_button 'LINE連携'
+        expect(page).to have_content 'LINE連携が完了しました'
+        expect(page).to have_content 'LINE連携解除'
+        expect(current_path).to eq account_setting_path
+        auth = Authentication.last
+        expect(auth.user).to eq user
+        expect(auth.provider).to eq 'line'
+        expect(auth.uid).to eq '123456'
+      end
+
+      it 'LINE連携解除ができること' do
+        visit account_setting_path
+        click_button 'LINE連携'
+        expect(page).to have_content 'LINE連携が完了しました'
+        auth = Authentication.last
+        expect(auth.user).to eq user
+        expect(auth.provider).to eq 'line'
+        expect(auth.uid).to eq '123456'
+        click_link 'LINE連携解除'
+        expect(page.accept_confirm).to eq 'LINE連携を解除してよろしいですか？'
+        expect(page).to have_content 'LINE連携を解除しました'
+        expect(current_path).to eq account_setting_path
+        expect(page).to have_content 'LINE連携'
+      end
+
+      it 'LINE連携ができないこと' do
+        other_user = create(:user, email: 'other@example.com')
+        create(:authentication, user: other_user, provider: 'line', uid: '123456')
+        visit account_setting_path
+        click_button 'LINE連携'
+        expect(page).to have_content 'そのLINEアカウントはすでに存在しています'
+        click_button 'LINE連携'
+        expect(current_path).to eq account_setting_path
+      end
+      
+      # ログイン手段がLINEしかない場合、解除できるとログインできなくなるため
+      it 'LINE連携解除ができないこと' do
+        logout
+        visit new_user_registration_path
+        click_button 'LINEで登録'
+        visit account_setting_path
+        click_link 'LINE連携解除'
+        expect(page.accept_confirm).to eq 'LINE連携を解除してよろしいですか？'
+        expect(page).to have_content 'LINEでログイン中のため解除できません'
+        expect(current_path).to eq account_setting_path
+        click_link 'LINE連携解除'
+      end
+    end
+
     context '管理' do
       before do
         visit confirm_destroy_account_setting_path

--- a/spec/system/account_settings_spec.rb
+++ b/spec/system/account_settings_spec.rb
@@ -358,15 +358,20 @@ RSpec.describe "AccountSettings", type: :system do
         expect(page).to have_content 'LINE連携を解除しました'
         expect(current_path).to eq account_setting_path
         expect(page).to have_content 'LINE連携'
+        expect(Authentication.count).to eq 0
       end
 
       it 'LINE連携ができないこと' do
         other_user = create(:user, email: 'other@example.com')
         create(:authentication, user: other_user, provider: 'line', uid: '123456')
         visit account_setting_path
+        auth = Authentication.last
+        expect(auth.user).to eq other_user
         click_button 'LINE連携'
         expect(page).to have_content 'そのLINEアカウントはすでに存在しています'
-        click_button 'LINE連携'
+        auth = Authentication.last
+        expect(auth.user).to eq other_user
+        expect(page).to have_content 'LINE連携'
         expect(current_path).to eq account_setting_path
       end
 
@@ -375,12 +380,17 @@ RSpec.describe "AccountSettings", type: :system do
         logout
         visit new_user_registration_path
         click_button 'LINEで登録'
+        user = User.last
         visit account_setting_path
         click_link 'LINE連携解除'
         expect(page.accept_confirm).to eq 'LINE連携を解除してよろしいですか？'
         expect(page).to have_content 'LINEでログイン中のため解除できません'
         expect(current_path).to eq account_setting_path
-        click_link 'LINE連携解除'
+        expect(page).to have_content 'LINE連携解除'
+        auth = Authentication.last
+        expect(auth.user).to eq user
+        expect(auth.provider).to eq 'line'
+        expect(auth.uid).to eq '123456'
       end
     end
 


### PR DESCRIPTION
## 概要
デプロイのため、develop ブランチを main ブランチにマージします

## 含まれる変更
- LINE連携機能の実装

## 動作確認
- [x] 既存の機能に問題がないこと
- [x] アカウント設定画面にLINE連携が表示されること
- [x] LINE連携、LINE連携解除ができること

## 補足
- 特記事項はございません