### PR TITLE
chore: line-bot-apiを2.7.0から2.8.0に更新

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
-    line-bot-api (2.7.0)
+    line-bot-api (2.8.0)
       base64 (~> 0.2)
       multipart-post (~> 2.4)
     lint_roller (1.1.0)


### PR DESCRIPTION
## 概要
line-bot-apiを`2.7.0`から`2.8.0`に更新しました

## 背景
dependabotの提案に対応するため

## 該当Issue
- なし

## 変更内容
- line-bot-apiを`2.7.0`から`2.8.0`に更新

## 確認方法
※環境構築は完了している前提
1. RSpec、CI（test）で問題がないこと

## 補足
- 特記事項はございません