### PR TITLE
chore: dependabotのマージ先をdevelopに変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,11 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  target-branch: develop
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: daily
+  target-branch: develop
   open-pull-requests-limit: 10


### PR DESCRIPTION
## 概要
dependabotのマージ先をdevelopに変更しました

## 背景
ライブラリなどの更新作業の効率化のため

## 該当Issue
- なし

## 変更内容
- `dependabot.yml`に`target-branch`を追記

## 補足
- 特にございません。